### PR TITLE
Replace "imports" of dependent softlayer projects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ quickdev: generate
 # Shorthand for building and installing just one plugin for local testing.
 # Run as (for example): make plugin-dev PLUGIN=provider-aws
 plugin-dev: generate
-	go install github.com/hashicorp/terraform/builtin/bins/$(PLUGIN)
+	go install github.com/TheWeatherCompany/terraform/builtin/bins/$(PLUGIN)
 	mv $(GOPATH)/bin/$(PLUGIN) $(GOPATH)/bin/terraform-$(PLUGIN)
 
 release: updatedeps
@@ -50,7 +50,7 @@ updatedeps:
 	go get -u golang.org/x/tools/cmd/stringer
 	go list ./... \
 		| xargs go list -f '{{join .Deps "\n"}}' \
-		| grep -v github.com/hashicorp/terraform \
+		| grep -v github.com/TheWeatherCompany/terraform \
 		| grep -v '/internal/' \
 		| sort -u \
 		| xargs go get -f -u -v

--- a/builtin/bins/provider-softlayer/main.go
+++ b/builtin/bins/provider-softlayer/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/hashicorp/terraform/builtin/providers/softlayer"
+	"github.com/TheWeatherCompany/terraform/builtin/providers/softlayer"
 	"github.com/hashicorp/terraform/plugin"
 )
 

--- a/builtin/providers/softlayer/config.go
+++ b/builtin/providers/softlayer/config.go
@@ -3,8 +3,8 @@ package softlayer
 import (
 	"log"
 
-	slclient "github.com/maximilien/softlayer-go/client"
-	softlayer "github.com/maximilien/softlayer-go/softlayer"
+	slclient "github.com/TheWeatherCompany/softlayer-go/client"
+	softlayer "github.com/TheWeatherCompany/softlayer-go/softlayer"
 )
 
 type Config struct {

--- a/builtin/providers/softlayer/resource_softlayer_ssh_key.go
+++ b/builtin/providers/softlayer/resource_softlayer_ssh_key.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform/helper/schema"
-	datatypes "github.com/maximilien/softlayer-go/data_types"
+	datatypes "github.com/TheWeatherCompany/softlayer-go/data_types"
 )
 
 func resourceSoftLayerSSHKey() *schema.Resource {

--- a/builtin/providers/softlayer/resource_softlayer_ssh_key_test.go
+++ b/builtin/providers/softlayer/resource_softlayer_ssh_key_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	datatypes "github.com/maximilien/softlayer-go/data_types"
+	datatypes "github.com/TheWeatherCompany/softlayer-go/data_types"
 )
 
 func TestAccSoftLayerSSHKey_Basic(t *testing.T) {

--- a/builtin/providers/softlayer/resource_softlayer_virtualserver.go
+++ b/builtin/providers/softlayer/resource_softlayer_virtualserver.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
-	datatypes "github.com/maximilien/softlayer-go/data_types"
+	datatypes "github.com/TheWeatherCompany/softlayer-go/data_types"
 )
 
 func resourceSoftLayerVirtualserver() *schema.Resource {

--- a/builtin/providers/softlayer/resource_softlayer_virtualserver_test.go
+++ b/builtin/providers/softlayer/resource_softlayer_virtualserver_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	datatypes "github.com/maximilien/softlayer-go/data_types"
+	datatypes "github.com/TheWeatherCompany/softlayer-go/data_types"
 )
 
 func TestAccSoftLayerVirtualserver_Basic(t *testing.T) {


### PR DESCRIPTION
1. Replace _imports_ of dependent softlayer projects (`softlayer-go` and `terraform-provider-softlayer`) from `github.com/maximilien` and `github.com/finn-no` to `github.com/TheWeatherCompany` 
2. Update make file to use TWC modules
