### PR TITLE
Remaining virtual guests CRUD changes

### DIFF
--- a/builtin/providers/softlayer/config.go
+++ b/builtin/providers/softlayer/config.go
@@ -15,6 +15,7 @@ type Config struct {
 type Client struct {
 	virtualGuestService softlayer.SoftLayer_Virtual_Guest_Service
 	sshKeyService softlayer.SoftLayer_Security_Ssh_Key_Service
+	productOrderService softlayer.SoftLayer_Product_Order_Service
 }
 
 func (c *Config) Client() (*Client, error) {

--- a/builtin/providers/softlayer/resource_softlayer_virtualserver.go
+++ b/builtin/providers/softlayer/resource_softlayer_virtualserver.go
@@ -87,6 +87,12 @@ func resourceSoftLayerVirtualserver() *schema.Resource {
 				Type:     schema.TypeBool,
 				Required: true,
 			},
+
+			"post_install_script_uri": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  nil,
+			},
 		},
 	}
 }
@@ -148,6 +154,7 @@ func resourceSoftLayerVirtualserverCreate(d *schema.ResourceData, meta interface
 		NetworkComponents: []datatypes.NetworkComponents{networkComponent},
 		BlockDevices: getBlockDevices(d),
 		LocalDiskFlag: d.Get("local_disk").(bool),
+		PostInstallScriptUri: d.Get("post_install_script_uri").(string),
 	}
 
 	userData := d.Get("user_data").(string)

--- a/builtin/providers/softlayer/resource_softlayer_virtualserver.go
+++ b/builtin/providers/softlayer/resource_softlayer_virtualserver.go
@@ -304,7 +304,6 @@ func resourceSoftLayerVirtualserverRead(d *schema.ResourceData, meta interface{}
 	d.Set("private_network_only", result.PrivateNetworkOnlyFlag)
 	d.Set("hourly_billing", result.HourlyBillingFlag)
 	d.Set("local_disk", result.LocalDiskFlag)
-	d.Set("post_install_script_uri", result.PostInstallScriptUri)
 	d.Set("frontend_vlan_id", result.PrimaryNetworkComponent.NetworkVlan.Id)
 	d.Set("backend_vlan_id", result.PrimaryBackendNetworkComponent.NetworkVlan.Id)
 

--- a/builtin/providers/softlayer/resource_softlayer_virtualserver.go
+++ b/builtin/providers/softlayer/resource_softlayer_virtualserver.go
@@ -225,11 +225,10 @@ func resourceSoftLayerVirtualserverCreate(d *schema.ResourceData, meta interface
 		}
 	}
 
-	userData := d.Get("user_data").(string)
-	if userData != "" {
+	if userData, ok := d.GetOk("user_data"); ok {
 		opts.UserData = []datatypes.UserData {
 			datatypes.UserData {
-				Value: userData,
+				Value: userData.(string),
 			},
 		}
 	}
@@ -342,9 +341,8 @@ func resourceSoftLayerVirtualserverUpdate(d *schema.ResourceData, meta interface
 	result.MaxMemory = d.Get("ram").(int)
 	result.NetworkComponents[0].MaxSpeed = d.Get("public_network_speed").(int)
 
-	userData := d.Get("user_data").(string)
-	if userData != "" {
-		client.SetMetadata(id, userData)
+	if d.HasChange("user_data") {
+		client.SetMetadata(id, d.Get("user_data").(string))
 	}
 
 	// TODO (igoonich): perform partial update using "upgrade" method (also add upgrade method to "softlayer-go")

--- a/builtin/providers/softlayer/resource_softlayer_virtualserver.go
+++ b/builtin/providers/softlayer/resource_softlayer_virtualserver.go
@@ -82,6 +82,11 @@ func resourceSoftLayerVirtualserver() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+
+			"local_disk": &schema.Schema{
+				Type:     schema.TypeBool,
+				Required: true,
+			},
 		},
 	}
 }
@@ -142,6 +147,7 @@ func resourceSoftLayerVirtualserverCreate(d *schema.ResourceData, meta interface
 		MaxMemory: d.Get("ram").(int),
 		NetworkComponents: []datatypes.NetworkComponents{networkComponent},
 		BlockDevices: getBlockDevices(d),
+		LocalDiskFlag: d.Get("local_disk").(bool),
 	}
 
 	userData := d.Get("user_data").(string)

--- a/builtin/providers/softlayer/resource_softlayer_virtualserver_test.go
+++ b/builtin/providers/softlayer/resource_softlayer_virtualserver_test.go
@@ -32,6 +32,10 @@ func TestAccSoftLayerVirtualserver_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"softlayer_virtualserver.terraform-acceptance-test-1", "public_network_speed", "10"),
 					resource.TestCheckResourceAttr(
+						"softlayer_virtualserver.terraform-acceptance-test-1", "hourly_billing", "true"),
+					resource.TestCheckResourceAttr(
+						"softlayer_virtualserver.terraform-acceptance-test-1", "private_network_only", "false"),
+					resource.TestCheckResourceAttr(
 						"softlayer_virtualserver.terraform-acceptance-test-1", "cpu", "1"),
 					resource.TestCheckResourceAttr(
 						"softlayer_virtualserver.terraform-acceptance-test-1", "ram", "1024"),
@@ -42,7 +46,7 @@ func TestAccSoftLayerVirtualserver_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"softlayer_virtualserver.terraform-acceptance-test-1", "disks.2", "20"),
 					resource.TestCheckResourceAttr(
-						"softlayer_virtualserver.terraform-acceptance-test-1", "user_data", "{\"fox\":[45]}"),
+						"softlayer_virtualserver.terraform-acceptance-test-1", "user_data", "{\"value\":\"newvalue\"}"),
 					resource.TestCheckResourceAttr(
 						"softlayer_virtualserver.terraform-acceptance-test-1", "local_disk", "false"),
 					resource.TestCheckResourceAttr(
@@ -68,6 +72,14 @@ func TestAccSoftLayerVirtualserver_Basic(t *testing.T) {
 				),
 			},
 
+			resource.TestStep{
+				Config: testAccCheckSoftLayerVirtualserverConfig_userDataUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSoftLayerVirtualserverExists("softlayer_virtualserver.terraform-acceptance-test-1", &server),
+					resource.TestCheckResourceAttr(
+						"softlayer_virtualserver.terraform-acceptance-test-1", "user_data", "updatedData"),
+				),
+			},
 		},
 	})
 }
@@ -140,10 +152,12 @@ resource "softlayer_virtualserver" "terraform-acceptance-test-1" {
     image = "DEBIAN_7_64"
     region = "ams01"
     public_network_speed = 10
+    hourly_billing = true
+	private_network_only = false
     cpu = 1
     ram = 1024
     disks = [25, 10, 20]
-    user_data = "{\"fox\":[45]}"
+    user_data = "{\"value\":\"newvalue\"}"
     local_disk = false
     post_install_script_uri = "https://www.google.com"
 }
@@ -156,10 +170,10 @@ resource "softlayer_virtualserver" "terraform-acceptance-test-1" {
     image = "DEBIAN_7_64"
     region = "ams01"
     public_network_speed = 10
+    hourly_billing = true
     cpu = 1
     ram = 1024
     disks = [25, 10, 20]
-    user_data = "{\"fox\":[45]}"
     local_disk = true
     post_install_script_uri = "https://www.google.com"
 }
@@ -172,10 +186,27 @@ resource "softlayer_virtualserver" "terraform-acceptance-test-1" {
     image = "DEBIAN_7_64"
     region = "ams01"
     public_network_speed = 10
+    hourly_billing = true
     cpu = 1
     ram = 1024
     disks = [25, 10, 20]
-    user_data = "{\"fox\":[45]}"
+    local_disk = true
+    post_install_script_uri = "https://www.ya.com"
+}
+`
+
+const testAccCheckSoftLayerVirtualserverConfig_userDataUpdate = `
+resource "softlayer_virtualserver" "terraform-acceptance-test-1" {
+    name = "terraform-test"
+    domain = "bar.example.com"
+    image = "DEBIAN_7_64"
+    region = "ams01"
+    public_network_speed = 10
+    hourly_billing = true
+    cpu = 1
+    ram = 1024
+    disks = [25, 10, 20]
+    user_data = "updatedData"
     local_disk = true
     post_install_script_uri = "https://www.ya.com"
 }

--- a/builtin/providers/softlayer/resource_softlayer_virtualserver_test.go
+++ b/builtin/providers/softlayer/resource_softlayer_virtualserver_test.go
@@ -69,6 +69,19 @@ func TestAccSoftLayerVirtualserver_Basic(t *testing.T) {
 				),
 			},
 
+		},
+	})
+}
+
+
+func TestAccSoftLayerVirtualserver_BlockDeviceTemplateGroup(t *testing.T) {
+	var server datatypes.SoftLayer_Virtual_Guest
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		CheckDestroy: testAccCheckSoftLayerVirtualserverDestroy,
+		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccCheckSoftLayerVirtualserverConfig_blockDeviceTemplateGroup,
 				Check: resource.ComposeTestCheckFunc(
@@ -76,15 +89,25 @@ func TestAccSoftLayerVirtualserver_Basic(t *testing.T) {
 					testAccCheckSoftLayerVirtualserverExists("softlayer_virtualserver.terraform-acceptance-test-BDTGroup", &server),
 				),
 			},
+		},
+	})
+}
 
+func TestAccSoftLayerVirtualserver_postInstallScriptUri(t *testing.T) {
+	var server datatypes.SoftLayer_Virtual_Guest
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		CheckDestroy: testAccCheckSoftLayerVirtualserverDestroy,
+		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccCheckSoftLayerVirtualserverConfig_postInstallScriptUri,
 				Check: resource.ComposeTestCheckFunc(
-					// it's enough if virtual server exists as url will be used after it's install.
+					// block_device_template_group_gid value is hardcoded. If it's valid then virtual server will be created well
 					testAccCheckSoftLayerVirtualserverExists("softlayer_virtualserver.terraform-acceptance-test-pISU", &server),
 				),
 			},
-
 		},
 	})
 }

--- a/builtin/providers/softlayer/resource_softlayer_virtualserver_test.go
+++ b/builtin/providers/softlayer/resource_softlayer_virtualserver_test.go
@@ -71,16 +71,6 @@ func TestAccSoftLayerVirtualserver_Basic(t *testing.T) {
 				),
 			},
 
-			// TODO: currently CPU upgrade test is disabled, due to unexpected behavior of field "dedicated_acct_host_only". For some reason it is reset by SoftLayer to "false". To be aligned with Daniel and Chris how to proceed with it.
-//			resource.TestStep{
-//				Config: testAccCheckSoftLayerVirtualserverConfig_vmUpgradeCPUs,
-//				Check: resource.ComposeTestCheckFunc(
-//					testAccCheckSoftLayerVirtualserverExists("softlayer_virtualserver.terraform-acceptance-test-1", &server),
-//					resource.TestCheckResourceAttr(
-//						"softlayer_virtualserver.terraform-acceptance-test-1", "cpu", "2"),
-//				),
-//			},
-
 			resource.TestStep{
 				Config: testAccCheckSoftLayerVirtualserverConfig_upgradeMemoryNetworkSpeed,
 				Check: resource.ComposeTestCheckFunc(
@@ -91,6 +81,16 @@ func TestAccSoftLayerVirtualserver_Basic(t *testing.T) {
 						"softlayer_virtualserver.terraform-acceptance-test-1", "public_network_speed", "100"),
 				),
 			},
+
+			// TODO: currently CPU upgrade test is disabled, due to unexpected behavior of field "dedicated_acct_host_only". For some reason it is reset by SoftLayer to "false". To be aligned with Daniel and Chris how to proceed with it.
+//			resource.TestStep{
+//				Config: testAccCheckSoftLayerVirtualserverConfig_vmUpgradeCPUs,
+//				Check: resource.ComposeTestCheckFunc(
+//					testAccCheckSoftLayerVirtualserverExists("softlayer_virtualserver.terraform-acceptance-test-1", &server),
+//					resource.TestCheckResourceAttr(
+//						"softlayer_virtualserver.terraform-acceptance-test-1", "cpu", "2"),
+//				),
+//			},
 
 		},
 	})
@@ -234,25 +234,6 @@ resource "softlayer_virtualserver" "terraform-acceptance-test-1" {
 }
 `
 
-const testAccCheckSoftLayerVirtualserverConfig_vmUpgradeCPUs = `
-resource "softlayer_virtualserver" "terraform-acceptance-test-1" {
-    name = "terraform-test"
-    domain = "bar.example.com"
-    image = "DEBIAN_7_64"
-    region = "ams01"
-    public_network_speed = 10
-    hourly_billing = true
-    cpu = 2
-    ram = 1024
-    disks = [25, 10, 20]
-    user_data = "updatedData"
-    dedicated_acct_host_only = true
-    local_disk = false
-    frontend_vlan_id = 1085155
-	backend_vlan_id = 1085157
-}
-`
-
 const testAccCheckSoftLayerVirtualserverConfig_upgradeMemoryNetworkSpeed = `
 resource "softlayer_virtualserver" "terraform-acceptance-test-1" {
     name = "terraform-test"
@@ -262,6 +243,25 @@ resource "softlayer_virtualserver" "terraform-acceptance-test-1" {
     public_network_speed = 100
     hourly_billing = true
     cpu = 1
+    ram = 2048
+    disks = [25, 10, 20]
+    user_data = "updatedData"
+    dedicated_acct_host_only = true
+    local_disk = false
+    frontend_vlan_id = 1085155
+	backend_vlan_id = 1085157
+}
+`
+
+const testAccCheckSoftLayerVirtualserverConfig_vmUpgradeCPUs = `
+resource "softlayer_virtualserver" "terraform-acceptance-test-1" {
+    name = "terraform-test"
+    domain = "bar.example.com"
+    image = "DEBIAN_7_64"
+    region = "ams01"
+    public_network_speed = 100
+    hourly_billing = true
+    cpu = 2
     ram = 2048
     disks = [25, 10, 20]
     user_data = "updatedData"

--- a/builtin/providers/softlayer/resource_softlayer_virtualserver_test.go
+++ b/builtin/providers/softlayer/resource_softlayer_virtualserver_test.go
@@ -50,8 +50,6 @@ func TestAccSoftLayerVirtualserver_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"softlayer_virtualserver.terraform-acceptance-test-1", "local_disk", "false"),
 					resource.TestCheckResourceAttr(
-						"softlayer_virtualserver.terraform-acceptance-test-1", "post_install_script_uri", "https://www.google.com"),
-					resource.TestCheckResourceAttr(
 						"softlayer_virtualserver.terraform-acceptance-test-1", "dedicated_acct_host_only", "true"),
 					// TODO: Will be changed in future, when the following issue is implemented: https://github.com/TheWeatherCompany/softlayer-go/issues/3.
 					// TODO: For now, as agreed in issue https://github.com/TheWeatherCompany/terraform/issues/5, use hardcoded values for VLANs.
@@ -70,6 +68,23 @@ func TestAccSoftLayerVirtualserver_Basic(t *testing.T) {
 						"softlayer_virtualserver.terraform-acceptance-test-1", "user_data", "updatedData"),
 				),
 			},
+
+			resource.TestStep{
+				Config: testAccCheckSoftLayerVirtualserverConfig_blockDeviceTemplateGroup,
+				Check: resource.ComposeTestCheckFunc(
+					// block_device_template_group_gid value is hardcoded. If it's valid then virtual server will be created well
+					testAccCheckSoftLayerVirtualserverExists("softlayer_virtualserver.terraform-acceptance-test-BDTGroup", &server),
+				),
+			},
+
+			resource.TestStep{
+				Config: testAccCheckSoftLayerVirtualserverConfig_postInstallScriptUri,
+				Check: resource.ComposeTestCheckFunc(
+					// it's enough if virtual server exists as url will be used after it's install.
+					testAccCheckSoftLayerVirtualserverExists("softlayer_virtualserver.terraform-acceptance-test-pISU", &server),
+				),
+			},
+
 		},
 	})
 }
@@ -150,7 +165,6 @@ resource "softlayer_virtualserver" "terraform-acceptance-test-1" {
     user_data = "{\"value\":\"newvalue\"}"
     dedicated_acct_host_only = true
     local_disk = false
-    post_install_script_uri = "https://www.google.com"
     frontend_vlan_id = 1085155
 	backend_vlan_id = 1085157
 }
@@ -169,8 +183,44 @@ resource "softlayer_virtualserver" "terraform-acceptance-test-1" {
     disks = [25, 10, 20]
     user_data = "updatedData"
     dedicated_acct_host_only = true
-    local_disk = true
-    post_install_script_uri = "https://www.ya.com"
+    local_disk = false
+    frontend_vlan_id = 1085155
+	backend_vlan_id = 1085157
+}
+`
+
+const testAccCheckSoftLayerVirtualserverConfig_postInstallScriptUri = `
+resource "softlayer_virtualserver" "terraform-acceptance-test-pISU" {
+    name = "terraform-test-pISU"
+    domain = "bar.example.com"
+    image = "DEBIAN_7_64"
+    region = "ams01"
+    public_network_speed = 10
+    hourly_billing = true
+	private_network_only = false
+    cpu = 1
+    ram = 1024
+    disks = [25, 10, 20]
+    user_data = "{\"value\":\"newvalue\"}"
+    dedicated_acct_host_only = true
+    local_disk = false
+    post_install_script_uri = "https://www.google.com"
+    frontend_vlan_id = 1085155
+	backend_vlan_id = 1085157
+}
+`
+
+const testAccCheckSoftLayerVirtualserverConfig_blockDeviceTemplateGroup = `
+resource "softlayer_virtualserver" "terraform-acceptance-test-BDTGroup" {
+    name = "terraform-test-blockDeviceTemplateGroup"
+    domain = "bar.example.com"
+    region = "ams01"
+    public_network_speed = 10
+    hourly_billing = false
+    cpu = 1
+    ram = 1024
+    local_disk = false
+    block_device_template_group_gid = "ac2b413c-9893-4178-8e62-a24cbe2864db"
     frontend_vlan_id = 1085155
 	backend_vlan_id = 1085157
 }

--- a/builtin/providers/softlayer/resource_softlayer_virtualserver_test.go
+++ b/builtin/providers/softlayer/resource_softlayer_virtualserver_test.go
@@ -46,9 +46,28 @@ func TestAccSoftLayerVirtualserver_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"softlayer_virtualserver.terraform-acceptance-test-1", "local_disk", "false"),
 					resource.TestCheckResourceAttr(
-						"softlayer_virtualserver.terraform-acceptance-test-1", "post_install_script_uri", "https://www.google.ru"),
+						"softlayer_virtualserver.terraform-acceptance-test-1", "post_install_script_uri", "https://www.google.com"),
 				),
 			},
+
+			resource.TestStep{
+				Config: testAccCheckSoftLayerVirtualserverConfig_localDiskUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSoftLayerVirtualserverExists("softlayer_virtualserver.terraform-acceptance-test-1", &server),
+					resource.TestCheckResourceAttr(
+						"softlayer_virtualserver.terraform-acceptance-test-1", "local_disk", "true"),
+				),
+			},
+
+			resource.TestStep{
+				Config: testAccCheckSoftLayerVirtualserverConfig_postInstallScriptUriUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSoftLayerVirtualserverExists("softlayer_virtualserver.terraform-acceptance-test-1", &server),
+					resource.TestCheckResourceAttr(
+						"softlayer_virtualserver.terraform-acceptance-test-1", "post_install_script_uri", "https://www.ya.com"),
+				),
+			},
+
 		},
 	})
 }
@@ -126,6 +145,38 @@ resource "softlayer_virtualserver" "terraform-acceptance-test-1" {
     disks = [25, 10, 20]
     user_data = "{\"fox\":[45]}"
     local_disk = false
-    post_install_script_uri = "https://www.google.ru"
+    post_install_script_uri = "https://www.google.com"
+}
+`
+
+const testAccCheckSoftLayerVirtualserverConfig_localDiskUpdate = `
+resource "softlayer_virtualserver" "terraform-acceptance-test-1" {
+    name = "terraform-test"
+    domain = "bar.example.com"
+    image = "DEBIAN_7_64"
+    region = "ams01"
+    public_network_speed = 10
+    cpu = 1
+    ram = 1024
+    disks = [25, 10, 20]
+    user_data = "{\"fox\":[45]}"
+    local_disk = true
+    post_install_script_uri = "https://www.google.com"
+}
+`
+
+const testAccCheckSoftLayerVirtualserverConfig_postInstallScriptUriUpdate = `
+resource "softlayer_virtualserver" "terraform-acceptance-test-1" {
+    name = "terraform-test"
+    domain = "bar.example.com"
+    image = "DEBIAN_7_64"
+    region = "ams01"
+    public_network_speed = 10
+    cpu = 1
+    ram = 1024
+    disks = [25, 10, 20]
+    user_data = "{\"fox\":[45]}"
+    local_disk = true
+    post_install_script_uri = "https://www.ya.com"
 }
 `

--- a/builtin/providers/softlayer/resource_softlayer_virtualserver_test.go
+++ b/builtin/providers/softlayer/resource_softlayer_virtualserver_test.go
@@ -51,24 +51,14 @@ func TestAccSoftLayerVirtualserver_Basic(t *testing.T) {
 						"softlayer_virtualserver.terraform-acceptance-test-1", "local_disk", "false"),
 					resource.TestCheckResourceAttr(
 						"softlayer_virtualserver.terraform-acceptance-test-1", "post_install_script_uri", "https://www.google.com"),
-				),
-			},
-
-			resource.TestStep{
-				Config: testAccCheckSoftLayerVirtualserverConfig_localDiskUpdate,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSoftLayerVirtualserverExists("softlayer_virtualserver.terraform-acceptance-test-1", &server),
 					resource.TestCheckResourceAttr(
-						"softlayer_virtualserver.terraform-acceptance-test-1", "local_disk", "true"),
-				),
-			},
-
-			resource.TestStep{
-				Config: testAccCheckSoftLayerVirtualserverConfig_postInstallScriptUriUpdate,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSoftLayerVirtualserverExists("softlayer_virtualserver.terraform-acceptance-test-1", &server),
+						"softlayer_virtualserver.terraform-acceptance-test-1", "dedicated_acct_host_only", "true"),
+					// TODO: Will be changed in future, when the following issue is implemented: https://github.com/TheWeatherCompany/softlayer-go/issues/3.
+					// TODO: For now, as agreed in issue https://github.com/TheWeatherCompany/terraform/issues/5, use hardcoded values for VLANs.
 					resource.TestCheckResourceAttr(
-						"softlayer_virtualserver.terraform-acceptance-test-1", "post_install_script_uri", "https://www.ya.com"),
+						"softlayer_virtualserver.terraform-acceptance-test-1", "frontend_vlan_id", "1085155"),
+					resource.TestCheckResourceAttr(
+						"softlayer_virtualserver.terraform-acceptance-test-1", "backend_vlan_id", "1085157"),
 				),
 			},
 
@@ -158,40 +148,11 @@ resource "softlayer_virtualserver" "terraform-acceptance-test-1" {
     ram = 1024
     disks = [25, 10, 20]
     user_data = "{\"value\":\"newvalue\"}"
+    dedicated_acct_host_only = true
     local_disk = false
     post_install_script_uri = "https://www.google.com"
-}
-`
-
-const testAccCheckSoftLayerVirtualserverConfig_localDiskUpdate = `
-resource "softlayer_virtualserver" "terraform-acceptance-test-1" {
-    name = "terraform-test"
-    domain = "bar.example.com"
-    image = "DEBIAN_7_64"
-    region = "ams01"
-    public_network_speed = 10
-    hourly_billing = true
-    cpu = 1
-    ram = 1024
-    disks = [25, 10, 20]
-    local_disk = true
-    post_install_script_uri = "https://www.google.com"
-}
-`
-
-const testAccCheckSoftLayerVirtualserverConfig_postInstallScriptUriUpdate = `
-resource "softlayer_virtualserver" "terraform-acceptance-test-1" {
-    name = "terraform-test"
-    domain = "bar.example.com"
-    image = "DEBIAN_7_64"
-    region = "ams01"
-    public_network_speed = 10
-    hourly_billing = true
-    cpu = 1
-    ram = 1024
-    disks = [25, 10, 20]
-    local_disk = true
-    post_install_script_uri = "https://www.ya.com"
+    frontend_vlan_id = 1085155
+	backend_vlan_id = 1085157
 }
 `
 
@@ -207,7 +168,10 @@ resource "softlayer_virtualserver" "terraform-acceptance-test-1" {
     ram = 1024
     disks = [25, 10, 20]
     user_data = "updatedData"
+    dedicated_acct_host_only = true
     local_disk = true
     post_install_script_uri = "https://www.ya.com"
+    frontend_vlan_id = 1085155
+	backend_vlan_id = 1085157
 }
 `

--- a/builtin/providers/softlayer/resource_softlayer_virtualserver_test.go
+++ b/builtin/providers/softlayer/resource_softlayer_virtualserver_test.go
@@ -43,6 +43,8 @@ func TestAccSoftLayerVirtualserver_Basic(t *testing.T) {
 						"softlayer_virtualserver.terraform-acceptance-test-1", "disks.2", "20"),
 					resource.TestCheckResourceAttr(
 						"softlayer_virtualserver.terraform-acceptance-test-1", "user_data", "{\"fox\":[45]}"),
+					resource.TestCheckResourceAttr(
+						"softlayer_virtualserver.terraform-acceptance-test-1", "local_disk", "false"),
 				),
 			},
 		},
@@ -121,5 +123,6 @@ resource "softlayer_virtualserver" "terraform-acceptance-test-1" {
     ram = 1024
     disks = [25, 10, 20]
     user_data = "{\"fox\":[45]}"
+    local_disk = false
 }
 `

--- a/builtin/providers/softlayer/resource_softlayer_virtualserver_test.go
+++ b/builtin/providers/softlayer/resource_softlayer_virtualserver_test.go
@@ -21,6 +21,7 @@ func TestAccSoftLayerVirtualserver_Basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccCheckSoftLayerVirtualserverConfig_basic,
+				Destroy: false,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSoftLayerVirtualserverExists("softlayer_virtualserver.terraform-acceptance-test-1", &server),
 					resource.TestCheckResourceAttr(
@@ -62,6 +63,7 @@ func TestAccSoftLayerVirtualserver_Basic(t *testing.T) {
 
 			resource.TestStep{
 				Config: testAccCheckSoftLayerVirtualserverConfig_userDataUpdate,
+				Destroy: false,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSoftLayerVirtualserverExists("softlayer_virtualserver.terraform-acceptance-test-1", &server),
 					resource.TestCheckResourceAttr(
@@ -69,10 +71,30 @@ func TestAccSoftLayerVirtualserver_Basic(t *testing.T) {
 				),
 			},
 
+			// TODO: currently CPU upgrade test is disabled, due to unexpected behavior of field "dedicated_acct_host_only". For some reason it is reset by SoftLayer to "false". To be aligned with Daniel and Chris how to proceed with it.
+//			resource.TestStep{
+//				Config: testAccCheckSoftLayerVirtualserverConfig_vmUpgradeCPUs,
+//				Check: resource.ComposeTestCheckFunc(
+//					testAccCheckSoftLayerVirtualserverExists("softlayer_virtualserver.terraform-acceptance-test-1", &server),
+//					resource.TestCheckResourceAttr(
+//						"softlayer_virtualserver.terraform-acceptance-test-1", "cpu", "2"),
+//				),
+//			},
+
+			resource.TestStep{
+				Config: testAccCheckSoftLayerVirtualserverConfig_upgradeMemoryNetworkSpeed,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSoftLayerVirtualserverExists("softlayer_virtualserver.terraform-acceptance-test-1", &server),
+					resource.TestCheckResourceAttr(
+						"softlayer_virtualserver.terraform-acceptance-test-1", "ram", "2048"),
+					resource.TestCheckResourceAttr(
+						"softlayer_virtualserver.terraform-acceptance-test-1", "public_network_speed", "100"),
+				),
+			},
+
 		},
 	})
 }
-
 
 func TestAccSoftLayerVirtualserver_BlockDeviceTemplateGroup(t *testing.T) {
 	var server datatypes.SoftLayer_Virtual_Guest
@@ -212,6 +234,44 @@ resource "softlayer_virtualserver" "terraform-acceptance-test-1" {
 }
 `
 
+const testAccCheckSoftLayerVirtualserverConfig_vmUpgradeCPUs = `
+resource "softlayer_virtualserver" "terraform-acceptance-test-1" {
+    name = "terraform-test"
+    domain = "bar.example.com"
+    image = "DEBIAN_7_64"
+    region = "ams01"
+    public_network_speed = 10
+    hourly_billing = true
+    cpu = 2
+    ram = 1024
+    disks = [25, 10, 20]
+    user_data = "updatedData"
+    dedicated_acct_host_only = true
+    local_disk = false
+    frontend_vlan_id = 1085155
+	backend_vlan_id = 1085157
+}
+`
+
+const testAccCheckSoftLayerVirtualserverConfig_upgradeMemoryNetworkSpeed = `
+resource "softlayer_virtualserver" "terraform-acceptance-test-1" {
+    name = "terraform-test"
+    domain = "bar.example.com"
+    image = "DEBIAN_7_64"
+    region = "ams01"
+    public_network_speed = 100
+    hourly_billing = true
+    cpu = 1
+    ram = 2048
+    disks = [25, 10, 20]
+    user_data = "updatedData"
+    dedicated_acct_host_only = true
+    local_disk = false
+    frontend_vlan_id = 1085155
+	backend_vlan_id = 1085157
+}
+`
+
 const testAccCheckSoftLayerVirtualserverConfig_postInstallScriptUri = `
 resource "softlayer_virtualserver" "terraform-acceptance-test-pISU" {
     name = "terraform-test-pISU"
@@ -228,8 +288,6 @@ resource "softlayer_virtualserver" "terraform-acceptance-test-pISU" {
     dedicated_acct_host_only = true
     local_disk = false
     post_install_script_uri = "https://www.google.com"
-    frontend_vlan_id = 1085155
-	backend_vlan_id = 1085157
 }
 `
 
@@ -244,7 +302,5 @@ resource "softlayer_virtualserver" "terraform-acceptance-test-BDTGroup" {
     ram = 1024
     local_disk = false
     block_device_template_group_gid = "ac2b413c-9893-4178-8e62-a24cbe2864db"
-    frontend_vlan_id = 1085155
-	backend_vlan_id = 1085157
 }
 `

--- a/builtin/providers/softlayer/resource_softlayer_virtualserver_test.go
+++ b/builtin/providers/softlayer/resource_softlayer_virtualserver_test.go
@@ -45,6 +45,8 @@ func TestAccSoftLayerVirtualserver_Basic(t *testing.T) {
 						"softlayer_virtualserver.terraform-acceptance-test-1", "user_data", "{\"fox\":[45]}"),
 					resource.TestCheckResourceAttr(
 						"softlayer_virtualserver.terraform-acceptance-test-1", "local_disk", "false"),
+					resource.TestCheckResourceAttr(
+						"softlayer_virtualserver.terraform-acceptance-test-1", "post_install_script_uri", "https://www.google.ru"),
 				),
 			},
 		},
@@ -124,5 +126,6 @@ resource "softlayer_virtualserver" "terraform-acceptance-test-1" {
     disks = [25, 10, 20]
     user_data = "{\"fox\":[45]}"
     local_disk = false
+    post_install_script_uri = "https://www.google.ru"
 }
 `


### PR DESCRIPTION
Includes `terraform` the changes for requested fields.

As discussed in the ticket we also additionally included _upgrading_ option of the virtual guests. Corresponding changes for the `softlayer-go` client can be found in PR (https://github.com/TheWeatherCompany/softlayer-go/pull/6) and should be merged first.

Tests for `virtual guests` take some more time as we create a few more resource now plus each additional upgrade request forces the creation of UPGRADE ticket on SoftLayer side and such ticket could be in progress for several minutes.
