### PR TITLE
Add softlayer_user resource type

### DIFF
--- a/builtin/providers/softlayer/config.go
+++ b/builtin/providers/softlayer/config.go
@@ -3,8 +3,8 @@ package softlayer
 import (
 	"log"
 
-	slclient "github.com/maximilien/softlayer-go/client"
-	softlayer "github.com/maximilien/softlayer-go/softlayer"
+	slclient "github.com/TheWeatherCompany/softlayer-go/client"
+	softlayer "github.com/TheWeatherCompany/softlayer-go/softlayer"
 )
 
 type Config struct {
@@ -16,6 +16,7 @@ type Client struct {
 	virtualGuestService softlayer.SoftLayer_Virtual_Guest_Service
 	sshKeyService       softlayer.SoftLayer_Security_Ssh_Key_Service
 	productOrderService softlayer.SoftLayer_Product_Order_Service
+	userCustomerService softlayer.SoftLayer_User_Customer_Service
 }
 
 func (c *Config) Client() (*Client, error) {
@@ -28,9 +29,20 @@ func (c *Config) Client() (*Client, error) {
 
 	sshKeyService, err := slc.GetSoftLayer_Security_Ssh_Key_Service()
 
+	if err != nil {
+		return nil, err
+	}
+
+	userCustomerService, err := slc.GetSoftLayer_User_Customer_Service()
+
+	if err != nil {
+		return nil, err
+	}
+
 	client := &Client{
 		virtualGuestService: virtualGuestService,
 		sshKeyService:       sshKeyService,
+		userCustomerService: userCustomerService,
 	}
 
 	log.Println("[INFO] Created SoftLayer client")

--- a/builtin/providers/softlayer/provider.go
+++ b/builtin/providers/softlayer/provider.go
@@ -25,6 +25,7 @@ func Provider() terraform.ResourceProvider {
 		ResourcesMap: map[string]*schema.Resource{
 			"softlayer_virtual_guest": resourceSoftLayerVirtualGuest(),
 			"softlayer_ssh_key":       resourceSoftLayerSSHKey(),
+			"softlayer_user":          resourceSoftLayerUserCustomer(),
 		},
 
 		ConfigureFunc: providerConfigure,

--- a/builtin/providers/softlayer/resource_softlayer_ssh_key.go
+++ b/builtin/providers/softlayer/resource_softlayer_ssh_key.go
@@ -6,8 +6,8 @@ import (
 	"strconv"
 	"strings"
 
+	datatypes "github.com/TheWeatherCompany/softlayer-go/data_types"
 	"github.com/hashicorp/terraform/helper/schema"
-	datatypes "github.com/maximilien/softlayer-go/data_types"
 )
 
 func resourceSoftLayerSSHKey() *schema.Resource {

--- a/builtin/providers/softlayer/resource_softlayer_ssh_key_test.go
+++ b/builtin/providers/softlayer/resource_softlayer_ssh_key_test.go
@@ -6,9 +6,9 @@ import (
 	"strings"
 	"testing"
 
+	datatypes "github.com/TheWeatherCompany/softlayer-go/data_types"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	datatypes "github.com/maximilien/softlayer-go/data_types"
 )
 
 func TestAccSoftLayerSSHKey_Basic(t *testing.T) {

--- a/builtin/providers/softlayer/resource_softlayer_user_customer.go
+++ b/builtin/providers/softlayer/resource_softlayer_user_customer.go
@@ -1,0 +1,400 @@
+package softlayer
+
+import (
+	"crypto/sha1"
+	"encoding/hex"
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+
+	datatypes "github.com/TheWeatherCompany/softlayer-go/data_types"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceSoftLayerUserCustomer() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceSoftLayerUserCustomerCreate,
+		Read:   resourceSoftLayerUserCustomerRead,
+		Update: resourceSoftLayerUserCustomerUpdate,
+		Delete: resourceSoftLayerUserCustomerDelete,
+		Exists: resourceSoftLayerUserCustomerExists,
+
+		Schema: map[string]*schema.Schema{
+			"id": &schema.Schema{
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+
+			"username": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"first_name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"last_name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"email": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"company_name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"address1": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"address2": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"city": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"state": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"country": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			// TODO Support more intuitive string values for timezone and user_status
+			"timezone": &schema.Schema{
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"user_status": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+				// Active by default
+				Default: 1001,
+			},
+			"password": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				StateFunc: func(v interface{}) string {
+					hash := sha1.Sum([]byte(v.(string)))
+					return hex.EncodeToString(hash[:])
+				},
+			},
+			"permissions": &schema.Schema{
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+			"has_api_key": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			"api_key": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+		},
+	}
+}
+
+// Create a SoftLayer_User_Customer_CustomerPermission_Permission object from the given string input
+func makePermission(p string) datatypes.SoftLayer_User_Customer_CustomerPermission_Permission {
+	return datatypes.SoftLayer_User_Customer_CustomerPermission_Permission{
+		Key:     "",
+		Name:    "",
+		KeyName: p,
+	}
+}
+
+// Convert a "set" of permission strings to a list of SoftLayer_User_Customer_CustomerPermission_Permissions
+func getPermissions(d *schema.ResourceData) []datatypes.SoftLayer_User_Customer_CustomerPermission_Permission {
+	permissionsSet := d.Get("permissions").(*schema.Set)
+
+	if permissionsSet.Len() == 0 {
+		return nil
+	}
+
+	permissions := make([]datatypes.SoftLayer_User_Customer_CustomerPermission_Permission, 0, permissionsSet.Len())
+	for _, elem := range permissionsSet.List() {
+		permission := makePermission(elem.(string))
+
+		permissions = append(permissions, permission)
+	}
+	return permissions
+}
+
+func resourceSoftLayerUserCustomerCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*Client).userCustomerService
+
+	// Build up our creation options
+	opts := datatypes.SoftLayer_User_Customer{
+		Username:    d.Get("username").(string),
+		FirstName:   d.Get("first_name").(string),
+		LastName:    d.Get("last_name").(string),
+		Email:       d.Get("email").(string),
+		CompanyName: d.Get("company_name").(string),
+		Address1:    d.Get("address1").(string),
+		City:        d.Get("city").(string),
+		State:       d.Get("state").(string),
+		Country:     d.Get("country").(string),
+		Timezone:    d.Get("timezone").(int),
+		UserStatus:  d.Get("user_status").(int),
+	}
+
+	if address2, ok := d.GetOk("address2"); ok {
+		opts.Address2 = address2.(string)
+	}
+
+	password := d.Get("password").(string)
+
+	res, err := client.CreateObject(opts, password)
+	if err != nil {
+		return fmt.Errorf("Error creating SoftLayer User: %s", err)
+	}
+
+	d.SetId(strconv.Itoa(res.Id))
+	log.Printf("[INFO] SoftLayer User: %d", res.Id)
+
+	permissions := getPermissions(d)
+
+	defaultPortalPermissions := []datatypes.SoftLayer_User_Customer_CustomerPermission_Permission{
+		{KeyName: "ACCESS_ALL_GUEST"},
+		{KeyName: "ACCESS_ALL_HARDWARE"},
+	}
+
+	log.Printf("Replacing default portal permissions assigned by SoftLayer with those specified in config")
+	err = client.RemoveBulkPortalPermission(res.Id, defaultPortalPermissions)
+	if err != nil {
+		return fmt.Errorf("Error removing default portal permissions for SoftLayer User: %s", err)
+	}
+
+	err = client.AddBulkPortalPermission(res.Id, permissions)
+	if err != nil {
+		return fmt.Errorf("Error setting portal permissions for SoftLayer User: %s", err)
+	}
+
+	create_api_key_flag := d.Get("has_api_key").(bool)
+	if create_api_key_flag {
+		// We have to create the API key only if the flag is true. If 'false' we do not
+		// take the delete action on the API key, as this is the create new user method,
+		// and not the edit method.
+		err = client.AddApiAuthenticationKey(res.Id)
+		if err != nil {
+			return fmt.Errorf("Error creating API key: %s", err)
+		}
+	}
+
+	return resourceSoftLayerUserCustomerRead(d, meta)
+}
+
+func resourceSoftLayerUserCustomerRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*Client).userCustomerService
+
+	userID, _ := strconv.Atoi(d.Id())
+
+	sluserObj, err := client.GetObject(userID)
+	if err != nil {
+		// If the key is somehow already destroyed, mark as
+		// successfully gone
+		if strings.Contains(err.Error(), "404 Not Found") {
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf("Error retrieving SoftLayer User: %s", err)
+	}
+
+	d.Set("id", sluserObj.Id)
+	d.Set("username", sluserObj.Username)
+	d.Set("email", sluserObj.Email)
+	d.Set("first_name", sluserObj.FirstName)
+	d.Set("last_name", sluserObj.LastName)
+	d.Set("company_name", sluserObj.CompanyName)
+	d.Set("address1", sluserObj.Address1)
+	d.Set("address2", sluserObj.Address2)
+	d.Set("city", sluserObj.City)
+	d.Set("state", sluserObj.State)
+	d.Set("country", sluserObj.Country)
+	d.Set("timezone", sluserObj.Timezone)
+	d.Set("user_status", sluserObj.UserStatus)
+
+	permissions := make([]string, 0, len(sluserObj.Permissions))
+	for _, elem := range sluserObj.Permissions {
+		permissions = append(permissions, elem.KeyName)
+	}
+	d.Set("permissions", permissions)
+
+	// If present, extract the api key from the SoftLayer response and set the field in the resource
+	if len(sluserObj.ApiAuthenticationKeys) > 0 {
+		d.Set("api_key", sluserObj.ApiAuthenticationKeys[0].AuthenticationKey) // as its a computed field
+	}
+
+	return nil
+}
+
+func resourceSoftLayerUserCustomerUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*Client).userCustomerService
+
+	sluid, err := strconv.Atoi(d.Id())
+	if err != nil {
+		return fmt.Errorf("Not a valid ID. Must be an integer: %s", err)
+	}
+
+	// Fetch the object, update the new values for the fields that have changed, and then pass the updated
+	// structure to the edit SoftLayer user method.
+	userObj, err := client.GetObject(sluid)
+	if err != nil {
+		return fmt.Errorf("Error retrieving softlayer_user resource: %s", err)
+	}
+
+	// Some fields cannot be updated such as username. Computed fields also cannot be updated
+	// by explicitly providing a value. So only update the fields that are editable.
+	// TODO: For now you may not update the password.
+	if d.HasChange("first_name") {
+		userObj.FirstName = d.Get("first_name").(string)
+	}
+	if d.HasChange("last_name") {
+		userObj.LastName = d.Get("last_name").(string)
+	}
+	if d.HasChange("email") {
+		userObj.Email = d.Get("email").(string)
+	}
+	if d.HasChange("company_name") {
+		userObj.CompanyName = d.Get("company_name").(string)
+	}
+	if d.HasChange("address1") {
+		userObj.Address1 = d.Get("address1").(string)
+	}
+	if d.HasChange("address2") {
+		userObj.Address2 = d.Get("address2").(string)
+	}
+	if d.HasChange("city") {
+		userObj.City = d.Get("city").(string)
+	}
+	if d.HasChange("state") {
+		userObj.State = d.Get("state").(string)
+	}
+	if d.HasChange("country") {
+		userObj.Country = d.Get("country").(string)
+	}
+	if d.HasChange("timezone") {
+		userObj.Timezone = d.Get("timezone").(int)
+	}
+	if d.HasChange("user_status") {
+		userObj.UserStatus = d.Get("user_status").(int)
+	}
+
+	_, err = client.EditObject(sluid, userObj)
+	if err != nil {
+		return fmt.Errorf("Error received while editing softlayer_user: %s", err)
+	}
+
+	if d.HasChange("permissions") {
+		// TODO Use set math functions (in schema.Set) to compute the difference, vs clearing and re-adding permissions
+		old, new := d.GetChange("permissions")
+
+		oldPermissions := make([]datatypes.SoftLayer_User_Customer_CustomerPermission_Permission, 0, old.(*schema.Set).Len())
+		newPermissions := make([]datatypes.SoftLayer_User_Customer_CustomerPermission_Permission, 0, new.(*schema.Set).Len())
+
+		for _, elem := range old.(*schema.Set).List() {
+			oldPermissions = append(oldPermissions, makePermission(elem.(string)))
+		}
+
+		for _, elem := range new.(*schema.Set).List() {
+			newPermissions = append(newPermissions, makePermission(elem.(string)))
+		}
+
+		// 'remove' all old permissions
+		err = client.RemoveBulkPortalPermission(sluid, oldPermissions)
+		if err != nil {
+			return fmt.Errorf("Error received while removing old permissions from softlayer_user: %s", err)
+		}
+
+		// 'add' new permission set
+		err = client.AddBulkPortalPermission(sluid, newPermissions)
+		if err != nil {
+			return fmt.Errorf("Error received while assigning new permissions to softlayer_user: %s", err)
+		}
+	}
+
+	if d.HasChange("has_api_key") {
+		// if true, then it means create an api key if none exists. Its a no-op if an api key already exists.
+		// else false means, delete the api key if one exists. Its a no-op if no api key exists.
+		api_key_flag := d.Get("has_api_key").(bool)
+
+		// Get the current keys.
+		keys := userObj.ApiAuthenticationKeys
+
+		// Create a key if flag is true, and a key does not already exist.
+		if api_key_flag {
+			if len(keys) == 0 { // means key does not exist, so create one.
+				err = client.AddApiAuthenticationKey(sluid)
+				if err != nil {
+					return fmt.Errorf("Error creating API key while editing softlayer_user resource: %s", err)
+				}
+				// get the details of the new one, so that you can update the terraform resource.
+				keys, err = client.GetApiAuthenticationKeys(sluid)
+				if err != nil {
+					return fmt.Errorf("Error fetching the newly created API key while editing softlayer_user resource: %s", err)
+				}
+			}
+			d.Set("api_key", keys[0].AuthenticationKey) // as api_key is a computed field
+		} else {
+			// If false, then delete the key if there was one.
+			if len(keys) > 0 {
+				_, err = client.RemoveApiAuthenticationKey(sluid, keys)
+				if err != nil {
+					return fmt.Errorf("Error deleting API key while editing softlayer_user resource: %s", err)
+				}
+			}
+			d.Set("api_key", nil)
+		}
+	}
+	return nil
+}
+
+func resourceSoftLayerUserCustomerDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*Client).userCustomerService
+
+	id, err := strconv.Atoi(d.Id())
+	if err != nil {
+		return fmt.Errorf("Error deleting SoftLayer user: %s", err)
+	}
+
+	log.Printf("[INFO] Deleting SoftLayer user: %d", id)
+	_, err = client.DeleteObject(id)
+	if err != nil {
+		return fmt.Errorf("Error deleting SoftLayer user: %s", err)
+	}
+
+	d.SetId("")
+	return nil
+}
+
+func resourceSoftLayerUserCustomerExists(d *schema.ResourceData, meta interface{}) (bool, error) {
+	client := meta.(*Client).userCustomerService
+
+	if client == nil {
+		return false, fmt.Errorf("The client was nil.")
+	}
+
+	keyId, err := strconv.Atoi(d.Id())
+	if err != nil {
+		return false, fmt.Errorf("Not a valid ID, must be an integer: %s", err)
+	}
+
+	result, err := client.GetObject(keyId)
+	return result.Id == keyId && err == nil, nil
+}

--- a/builtin/providers/softlayer/resource_softlayer_user_customer_test.go
+++ b/builtin/providers/softlayer/resource_softlayer_user_customer_test.go
@@ -1,0 +1,209 @@
+package softlayer
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	"crypto/sha1"
+	"encoding/hex"
+	datatypes "github.com/TheWeatherCompany/softlayer-go/data_types"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"regexp"
+)
+
+func TestAccSoftLayerUserCustomer_Basic(t *testing.T) {
+	var user datatypes.SoftLayer_User_Customer
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSoftLayerUserCustomerDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckSoftLayerUserCustomerConfig_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSoftLayerUserCustomerExists("softlayer_user.testuser", &user),
+					resource.TestCheckResourceAttr(
+						"softlayer_user.testuser", "username", testAccRandomUserName),
+					resource.TestCheckResourceAttr(
+						"softlayer_user.testuser", "first_name", "first_name"),
+					resource.TestCheckResourceAttr(
+						"softlayer_user.testuser", "last_name", "last_name"),
+					resource.TestCheckResourceAttr(
+						"softlayer_user.testuser", "email", "first.last@example.com"),
+					resource.TestCheckResourceAttr(
+						"softlayer_user.testuser", "company_name", "company_name"),
+					resource.TestCheckResourceAttr(
+						"softlayer_user.testuser", "address1", "1 Main St."),
+					resource.TestCheckResourceAttr(
+						"softlayer_user.testuser", "address2", "Suite 345"),
+					resource.TestCheckResourceAttr(
+						"softlayer_user.testuser", "city", "Atlanta"),
+					resource.TestCheckResourceAttr(
+						"softlayer_user.testuser", "state", "GA"),
+					resource.TestCheckResourceAttr(
+						"softlayer_user.testuser", "country", "US"),
+					resource.TestCheckResourceAttr(
+						"softlayer_user.testuser", "timezone", "114"),
+					resource.TestCheckResourceAttr(
+						"softlayer_user.testuser", "user_status", "1001"),
+					resource.TestCheckResourceAttr(
+						"softlayer_user.testuser", "password", hash(testAccUserPassword)),
+					resource.TestCheckResourceAttr(
+						"softlayer_user.testuser", "permissions.#", "2"),
+					resource.TestCheckResourceAttr(
+						"softlayer_user.testuser", "has_api_key", "true"),
+					resource.TestMatchResourceAttr(
+						"softlayer_user.testuser", "api_key", apiKeyRegexp),
+				),
+			},
+
+			resource.TestStep{
+				Config: testAccCheckSoftLayerUserCustomerConfig_updated,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"softlayer_user.testuser", "username", testAccRandomUserName),
+					resource.TestCheckResourceAttr(
+						"softlayer_user.testuser", "first_name", "new_first_name"),
+					resource.TestCheckResourceAttr(
+						"softlayer_user.testuser", "last_name", "new_last_name"),
+					resource.TestCheckResourceAttr(
+						"softlayer_user.testuser", "email", "new_first.new_last@example.com"),
+					resource.TestCheckResourceAttr(
+						"softlayer_user.testuser", "company_name", "new_company_name"),
+					resource.TestCheckResourceAttr(
+						"softlayer_user.testuser", "address1", "1 1st Avenue"),
+					resource.TestCheckResourceAttr(
+						"softlayer_user.testuser", "address2", "Apartment 2"),
+					resource.TestCheckResourceAttr(
+						"softlayer_user.testuser", "city", "Montreal"),
+					resource.TestCheckResourceAttr(
+						"softlayer_user.testuser", "state", "QC"),
+					resource.TestCheckResourceAttr(
+						"softlayer_user.testuser", "country", "CA"),
+					resource.TestCheckResourceAttr(
+						"softlayer_user.testuser", "timezone", "117"),
+					resource.TestCheckResourceAttr(
+						"softlayer_user.testuser", "user_status", "1002"),
+					resource.TestCheckResourceAttr(
+						"softlayer_user.testuser", "password", hash(testAccUserPassword)),
+					resource.TestCheckResourceAttr(
+						"softlayer_user.testuser", "permissions.#", "3"),
+					resource.TestCheckResourceAttr(
+						"softlayer_user.testuser", "has_api_key", "false"),
+					resource.TestCheckResourceAttr(
+						"softlayer_user.testuser", "api_key", ""),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckSoftLayerUserCustomerDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*Client).userCustomerService
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "softlayer_user" {
+			continue
+		}
+
+		userID, _ := strconv.Atoi(rs.Primary.ID)
+
+		// Try to find the user
+		user, err := client.GetObject(userID)
+
+		// Users are not immediately deleted, but rather placed into a 'cancel_pending' (1021) status
+		if err != nil || user.UserStatus != 1021 {
+			return fmt.Errorf("SoftLayer User still exists")
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckSoftLayerUserCustomerExists(n string, user *datatypes.SoftLayer_User_Customer) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Record ID is set")
+		}
+
+		userID, _ := strconv.Atoi(rs.Primary.ID)
+
+		client := testAccProvider.Meta().(*Client).userCustomerService
+		foundUser, err := client.GetObject(userID)
+
+		if err != nil {
+			return err
+		}
+
+		if strconv.Itoa(int(foundUser.Id)) != rs.Primary.ID {
+			return fmt.Errorf("Record not found")
+		}
+
+		*user = foundUser
+
+		return nil
+	}
+}
+
+var testAccCheckSoftLayerUserCustomerConfig_basic = fmt.Sprintf(`
+resource "softlayer_user" "testuser" {
+    username = "%s"
+    first_name = "first_name"
+    last_name = "last_name"
+    email = "first.last@example.com"
+    company_name = "company_name"
+    address1 = "1 Main St."
+    address2 = "Suite 345"
+    city = "Atlanta"
+    state = "GA"
+    country = "US"
+    timezone = 114
+    password = "%s"
+    permissions = [
+        "SERVER_ADD",
+        "ACCESS_ALL_GUEST"
+    ]
+    has_api_key = true
+}`, testAccRandomUserName, testAccUserPassword)
+
+var testAccCheckSoftLayerUserCustomerConfig_updated = fmt.Sprintf(`
+resource "softlayer_user" "testuser" {
+    username = "%s"
+    first_name = "new_first_name"
+    last_name = "new_last_name"
+    email = "new_first.new_last@example.com"
+    company_name = "new_company_name"
+    address1 = "1 1st Avenue"
+    address2 = "Apartment 2"
+    city = "Montreal"
+    state = "QC"
+    country = "CA"
+    timezone = 117
+    user_status = 1002
+    password = "%s"
+    permissions = [
+        "SERVER_ADD",
+        "ACCESS_ALL_HARDWARE",
+        "TICKET_EDIT"
+    ]
+    has_api_key = false
+}`, testAccRandomUserName, testAccUserPassword)
+
+var testAccRandomUserName = resource.UniqueId()
+var testAccUserPassword = "T3stp@ss"
+var apiKeyRegexp, _ = regexp.Compile(`\w+`)
+
+// Function used by provider for hashing passwords
+func hash(v interface{}) string {
+	hash := sha1.Sum([]byte(v.(string)))
+	return hex.EncodeToString(hash[:])
+}

--- a/builtin/providers/softlayer/resource_softlayer_virtual_guest.go
+++ b/builtin/providers/softlayer/resource_softlayer_virtual_guest.go
@@ -7,10 +7,10 @@ import (
 	"time"
 
 	"encoding/base64"
+	datatypes "github.com/TheWeatherCompany/softlayer-go/data_types"
+	"github.com/TheWeatherCompany/softlayer-go/softlayer"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
-	datatypes "github.com/maximilien/softlayer-go/data_types"
-	"github.com/maximilien/softlayer-go/softlayer"
 	"math"
 	"strings"
 )

--- a/builtin/providers/softlayer/resource_softlayer_virtual_guest_test.go
+++ b/builtin/providers/softlayer/resource_softlayer_virtual_guest_test.go
@@ -6,9 +6,9 @@ import (
 	"strings"
 	"testing"
 
+	datatypes "github.com/TheWeatherCompany/softlayer-go/data_types"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	datatypes "github.com/maximilien/softlayer-go/data_types"
 )
 
 func TestAccSoftLayerVirtualGuest_Basic(t *testing.T) {

--- a/vendor/github.com/TheWeatherCompany/softlayer-go/LICENSE
+++ b/vendor/github.com/TheWeatherCompany/softlayer-go/LICENSE
@@ -1,0 +1,201 @@
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/TheWeatherCompany/softlayer-go/client/http_client.go
+++ b/vendor/github.com/TheWeatherCompany/softlayer-go/client/http_client.go
@@ -1,0 +1,214 @@
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httputil"
+	"os"
+	"path/filepath"
+	"regexp"
+	"text/template"
+)
+
+const NON_VERBOSE = "NON_VERBOSE"
+
+type HttpClient struct {
+	HTTPClient *http.Client
+
+	username string
+	password string
+
+	useHttps bool
+
+	apiUrl string
+
+	nonVerbose bool
+
+	templatePath string
+}
+
+func NewHttpsClient(username, password, apiUrl, templatePath string) *HttpClient {
+	return NewHttpClient(username, password, apiUrl, templatePath, true)
+}
+
+func NewHttpClient(username, password, apiUrl, templatePath string, useHttps bool) *HttpClient {
+	pwd, err := os.Getwd()
+	if err != nil {
+		panic(err)
+	}
+
+	hClient := &HttpClient{
+		username: username,
+		password: password,
+
+		useHttps: useHttps,
+
+		apiUrl: apiUrl,
+
+		templatePath: filepath.Join(pwd, templatePath),
+
+		HTTPClient: http.DefaultClient,
+
+		nonVerbose: checkNonVerbose(),
+	}
+
+	return hClient
+}
+
+// Public methods
+
+func (slc *HttpClient) DoRawHttpRequestWithObjectMask(path string, masks []string, requestType string, requestBody *bytes.Buffer) ([]byte, int, error) {
+	url := fmt.Sprintf("%s://%s:%s@%s/%s", slc.scheme(), slc.username, slc.password, slc.apiUrl, path)
+
+	url += "?objectMask="
+	for i := 0; i < len(masks); i++ {
+		url += masks[i]
+		if i != len(masks)-1 {
+			url += ";"
+		}
+	}
+
+	return slc.makeHttpRequest(url, requestType, requestBody)
+}
+
+func (slc *HttpClient) DoRawHttpRequestWithObjectFilter(path string, filters string, requestType string, requestBody *bytes.Buffer) ([]byte, int, error) {
+	url := fmt.Sprintf("%s://%s:%s@%s/%s", slc.scheme(), slc.username, slc.password, slc.apiUrl, path)
+	url += "?objectFilter=" + filters
+
+	return slc.makeHttpRequest(url, requestType, requestBody)
+}
+
+func (slc *HttpClient) DoRawHttpRequestWithObjectFilterAndObjectMask(path string, masks []string, filters string, requestType string, requestBody *bytes.Buffer) ([]byte, int, error) {
+	url := fmt.Sprintf("%s://%s:%s@%s/%s", slc.scheme(), slc.username, slc.password, slc.apiUrl, path)
+
+	url += "?objectFilter=" + filters
+
+	url += "&objectMask=filteredMask["
+	for i := 0; i < len(masks); i++ {
+		url += masks[i]
+		if i != len(masks)-1 {
+			url += ";"
+		}
+	}
+	url += "]"
+
+	return slc.makeHttpRequest(url, requestType, requestBody)
+}
+
+func (slc *HttpClient) DoRawHttpRequest(path string, requestType string, requestBody *bytes.Buffer) ([]byte, int, error) {
+	url := fmt.Sprintf("%s://%s:%s@%s/%s", slc.scheme(), slc.username, slc.password, slc.apiUrl, path)
+	return slc.makeHttpRequest(url, requestType, requestBody)
+}
+
+func (slc *HttpClient) GenerateRequestBody(templateData interface{}) (*bytes.Buffer, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return nil, err
+	}
+
+	bodyTemplate := template.Must(template.ParseFiles(filepath.Join(cwd, slc.templatePath)))
+	body := new(bytes.Buffer)
+	bodyTemplate.Execute(body, templateData)
+
+	return body, nil
+}
+
+func (slc *HttpClient) HasErrors(body map[string]interface{}) error {
+	if errString, ok := body["error"]; !ok {
+		return nil
+	} else {
+		return errors.New(errString.(string))
+	}
+}
+
+func (slc *HttpClient) CheckForHttpResponseErrors(data []byte) error {
+	var decodedResponse map[string]interface{}
+	err := json.Unmarshal(data, &decodedResponse)
+	if err != nil {
+		return err
+	}
+
+	if err := slc.HasErrors(decodedResponse); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Private methods
+
+func (slc *HttpClient) scheme() string {
+	if !slc.useHttps {
+		return "http"
+	}
+
+	return "https"
+}
+
+func (slc *HttpClient) makeHttpRequest(url string, requestType string, requestBody *bytes.Buffer) ([]byte, int, error) {
+	req, err := http.NewRequest(requestType, url, requestBody)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	bs, err := httputil.DumpRequest(req, true)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	if !slc.nonVerbose {
+		fmt.Fprintf(os.Stderr, "\n---\n[softlayer-go] Request:\n%s\n", hideCredentials(string(bs)))
+	}
+
+	resp, err := slc.HTTPClient.Do(req)
+	if err != nil {
+		return nil, 520, err
+	}
+
+	defer resp.Body.Close()
+
+	bs, err = httputil.DumpResponse(resp, true)
+	if err != nil {
+		return nil, resp.StatusCode, err
+	}
+
+	if !slc.nonVerbose {
+		fmt.Fprintf(os.Stderr, "[softlayer-go] Response:\n%s\n", hideCredentials(string(bs)))
+	}
+
+	responseBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, resp.StatusCode, err
+	}
+
+	return responseBody, resp.StatusCode, nil
+}
+
+// Private functions
+
+func hideCredentials(s string) string {
+	hiddenStr := "\"password\":\"******\""
+	r := regexp.MustCompile(`"password":"[^"]*"`)
+
+	return r.ReplaceAllString(s, hiddenStr)
+}
+
+func checkNonVerbose() bool {
+	slGoNonVerbose := os.Getenv(NON_VERBOSE)
+	switch slGoNonVerbose {
+	case "yes":
+		return true
+	case "YES":
+		return true
+	case "true":
+		return true
+	case "TRUE":
+		return true
+	}
+
+	return false
+}

--- a/vendor/github.com/TheWeatherCompany/softlayer-go/client/softlayer_client.go
+++ b/vendor/github.com/TheWeatherCompany/softlayer-go/client/softlayer_client.go
@@ -1,0 +1,319 @@
+package client
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	services "github.com/TheWeatherCompany/softlayer-go/services"
+	softlayer "github.com/TheWeatherCompany/softlayer-go/softlayer"
+	"io/ioutil"
+	"net/http"
+	"net/http/httputil"
+	"os"
+)
+
+const (
+	SOFTLAYER_API_URL  = "api.softlayer.com/rest/v3"
+	TEMPLATE_ROOT_PATH = "templates"
+)
+
+type SoftLayerClient struct {
+	username string
+	apiKey   string
+
+	HTTPClient *http.Client
+
+	HttpClient softlayer.HttpClient
+
+	softLayerServices map[string]softlayer.Service
+
+	nonVerbose bool
+}
+
+func NewSoftLayerClient(username, apiKey string) *SoftLayerClient {
+	slc := &SoftLayerClient{
+		HttpClient: NewHttpsClient(username, apiKey, SOFTLAYER_API_URL, TEMPLATE_ROOT_PATH),
+
+		softLayerServices: map[string]softlayer.Service{},
+	}
+
+	slc.initSoftLayerServices()
+
+	return slc
+}
+
+//softlayer.Client interface methods
+
+func (slc *SoftLayerClient) GetHttpClient() softlayer.HttpClient {
+	return slc.HttpClient
+}
+
+func (slc *SoftLayerClient) GetService(serviceName string) (softlayer.Service, error) {
+	slService, ok := slc.softLayerServices[serviceName]
+	if !ok {
+		return nil, errors.New(fmt.Sprintf("softlayer-go does not support service '%s'", serviceName))
+	}
+
+	return slService, nil
+}
+
+func (slc *SoftLayerClient) GetSoftLayer_Account_Service() (softlayer.SoftLayer_Account_Service, error) {
+	slService, err := slc.GetService("SoftLayer_Account")
+	if err != nil {
+		return nil, err
+	}
+
+	return slService.(softlayer.SoftLayer_Account_Service), nil
+}
+
+func (slc *SoftLayerClient) GetSoftLayer_User_Customer_Service() (softlayer.SoftLayer_User_Customer_Service, error) {
+	slService, err := slc.GetService("SoftLayer_User_Customer")
+	if err != nil {
+		return nil, err
+	}
+
+	return slService.(softlayer.SoftLayer_User_Customer_Service), nil
+}
+
+func (slc *SoftLayerClient) GetSoftLayer_Virtual_Guest_Service() (softlayer.SoftLayer_Virtual_Guest_Service, error) {
+	slService, err := slc.GetService("SoftLayer_Virtual_Guest")
+	if err != nil {
+		return nil, err
+	}
+
+	return slService.(softlayer.SoftLayer_Virtual_Guest_Service), nil
+}
+
+func (slc *SoftLayerClient) GetSoftLayer_Dns_Domain_Service() (softlayer.SoftLayer_Dns_Domain_Service, error) {
+	slService, err := slc.GetService("SoftLayer_Dns_Domain")
+	if err != nil {
+		return nil, err
+	}
+
+	return slService.(softlayer.SoftLayer_Dns_Domain_Service), nil
+}
+
+func (slc *SoftLayerClient) GetSoftLayer_Virtual_Disk_Image_Service() (softlayer.SoftLayer_Virtual_Disk_Image_Service, error) {
+	slService, err := slc.GetService("SoftLayer_Virtual_Disk_Image")
+	if err != nil {
+		return nil, err
+	}
+
+	return slService.(softlayer.SoftLayer_Virtual_Disk_Image_Service), nil
+}
+
+func (slc *SoftLayerClient) GetSoftLayer_Security_Ssh_Key_Service() (softlayer.SoftLayer_Security_Ssh_Key_Service, error) {
+	slService, err := slc.GetService("SoftLayer_Security_Ssh_Key")
+	if err != nil {
+		return nil, err
+	}
+
+	return slService.(softlayer.SoftLayer_Security_Ssh_Key_Service), nil
+}
+
+func (slc *SoftLayerClient) GetSoftLayer_Product_Package_Service() (softlayer.SoftLayer_Product_Package_Service, error) {
+	slService, err := slc.GetService("SoftLayer_Product_Package")
+	if err != nil {
+		return nil, err
+	}
+
+	return slService.(softlayer.SoftLayer_Product_Package_Service), nil
+}
+
+func (slc *SoftLayerClient) GetSoftLayer_Virtual_Guest_Block_Device_Template_Group_Service() (softlayer.SoftLayer_Virtual_Guest_Block_Device_Template_Group_Service, error) {
+	slService, err := slc.GetService("SoftLayer_Virtual_Guest_Block_Device_Template_Group")
+	if err != nil {
+		return nil, err
+	}
+
+	return slService.(softlayer.SoftLayer_Virtual_Guest_Block_Device_Template_Group_Service), nil
+}
+
+func (slc *SoftLayerClient) GetSoftLayer_Network_Storage_Service() (softlayer.SoftLayer_Network_Storage_Service, error) {
+	slService, err := slc.GetService("SoftLayer_Network_Storage")
+	if err != nil {
+		return nil, err
+	}
+
+	return slService.(softlayer.SoftLayer_Network_Storage_Service), nil
+}
+
+func (slc *SoftLayerClient) GetSoftLayer_Network_Storage_Allowed_Host_Service() (softlayer.SoftLayer_Network_Storage_Allowed_Host_Service, error) {
+	slService, err := slc.GetService("SoftLayer_Network_Storage_Allowed_Host")
+	if err != nil {
+		return nil, err
+	}
+
+	return slService.(softlayer.SoftLayer_Network_Storage_Allowed_Host_Service), nil
+}
+
+func (slc *SoftLayerClient) GetSoftLayer_Product_Order_Service() (softlayer.SoftLayer_Product_Order_Service, error) {
+	slService, err := slc.GetService("SoftLayer_Product_Order")
+	if err != nil {
+		return nil, err
+	}
+
+	return slService.(softlayer.SoftLayer_Product_Order_Service), nil
+}
+
+func (slc *SoftLayerClient) GetSoftLayer_Billing_Item_Cancellation_Request_Service() (softlayer.SoftLayer_Billing_Item_Cancellation_Request_Service, error) {
+	slService, err := slc.GetService("SoftLayer_Billing_Item_Cancellation_Request")
+	if err != nil {
+		return nil, err
+	}
+
+	return slService.(softlayer.SoftLayer_Billing_Item_Cancellation_Request_Service), nil
+}
+
+func (slc *SoftLayerClient) GetSoftLayer_Billing_Item_Service() (softlayer.SoftLayer_Billing_Item_Service, error) {
+	slService, err := slc.GetService("SoftLayer_Billing_Item")
+	if err != nil {
+		return nil, err
+	}
+
+	return slService.(softlayer.SoftLayer_Billing_Item_Service), nil
+}
+
+func (slc *SoftLayerClient) GetSoftLayer_Hardware_Service() (softlayer.SoftLayer_Hardware_Service, error) {
+	slService, err := slc.GetService("SoftLayer_Hardware")
+	if err != nil {
+		return nil, err
+	}
+
+	return slService.(softlayer.SoftLayer_Hardware_Service), nil
+}
+
+func (slc *SoftLayerClient) GetSoftLayer_Dns_Domain_ResourceRecord_Service() (softlayer.SoftLayer_Dns_Domain_ResourceRecord_Service, error) {
+	slService, err := slc.GetService("SoftLayer_Dns_Domain_ResourceRecord")
+	if err != nil {
+		return nil, err
+	}
+
+	return slService.(softlayer.SoftLayer_Dns_Domain_ResourceRecord_Service), nil
+}
+
+func (slc *SoftLayerClient) GetSoftLayer_Network_Application_Delivery_Controller_Service() (softlayer.SoftLayer_Network_Application_Delivery_Controller_Service, error) {
+	slService, err := slc.GetService("SoftLayer_Network_Application_Delivery_Controller_Service")
+	if err != nil {
+		return nil, err
+	}
+
+	return slService.(softlayer.SoftLayer_Network_Application_Delivery_Controller_Service), nil
+}
+
+func (slc *SoftLayerClient) GetSoftLayer_Security_Certificate_Service() (softlayer.SoftLayer_Security_Certificate_Service, error) {
+	slService, err := slc.GetService("SoftLayer_Security_Certificate")
+	if err != nil {
+		return nil, err
+	}
+
+	return slService.(softlayer.SoftLayer_Security_Certificate_Service), nil
+}
+
+//Public methods
+
+func (slc *SoftLayerClient) DoRawHttpRequestWithObjectMask(path string, masks []string, requestType string, requestBody *bytes.Buffer) ([]byte, error) {
+	url := fmt.Sprintf("https://%s:%s@%s/%s", slc.username, slc.apiKey, SOFTLAYER_API_URL, path)
+
+	url += "?objectMask="
+	for i := 0; i < len(masks); i++ {
+		url += masks[i]
+		if i != len(masks)-1 {
+			url += ";"
+		}
+	}
+
+	return slc.makeHttpRequest(url, requestType, requestBody)
+}
+
+func (slc *SoftLayerClient) DoRawHttpRequestWithObjectFilter(path string, filters string, requestType string, requestBody *bytes.Buffer) ([]byte, error) {
+	url := fmt.Sprintf("https://%s:%s@%s/%s", slc.username, slc.apiKey, SOFTLAYER_API_URL, path)
+	url += "?objectFilter=" + filters
+
+	return slc.makeHttpRequest(url, requestType, requestBody)
+}
+
+func (slc *SoftLayerClient) DoRawHttpRequestWithObjectFilterAndObjectMask(path string, masks []string, filters string, requestType string, requestBody *bytes.Buffer) ([]byte, error) {
+	url := fmt.Sprintf("https://%s:%s@%s/%s", slc.username, slc.apiKey, SOFTLAYER_API_URL, path)
+
+	url += "?objectFilter=" + filters
+
+	url += "&objectMask=filteredMask["
+	for i := 0; i < len(masks); i++ {
+		url += masks[i]
+		if i != len(masks)-1 {
+			url += ";"
+		}
+	}
+	url += "]"
+
+	return slc.makeHttpRequest(url, requestType, requestBody)
+}
+
+func (slc *SoftLayerClient) DoRawHttpRequest(path string, requestType string, requestBody *bytes.Buffer) ([]byte, error) {
+	url := fmt.Sprintf("https://%s:%s@%s/%s", slc.username, slc.apiKey, SOFTLAYER_API_URL, path)
+	return slc.makeHttpRequest(url, requestType, requestBody)
+}
+
+//Private methods
+
+func (slc *SoftLayerClient) initSoftLayerServices() {
+	slc.softLayerServices["SoftLayer_Account"] = services.NewSoftLayer_Account_Service(slc)
+	slc.softLayerServices["SoftLayer_User_Customer"] = services.NewSoftLayer_User_Customer_Service(slc)
+	slc.softLayerServices["SoftLayer_Virtual_Guest"] = services.NewSoftLayer_Virtual_Guest_Service(slc)
+	slc.softLayerServices["SoftLayer_Virtual_Disk_Image"] = services.NewSoftLayer_Virtual_Disk_Image_Service(slc)
+	slc.softLayerServices["SoftLayer_Security_Ssh_Key"] = services.NewSoftLayer_Security_Ssh_Key_Service(slc)
+	slc.softLayerServices["SoftLayer_Product_Package"] = services.NewSoftLayer_Product_Package_Service(slc)
+	slc.softLayerServices["SoftLayer_Network_Storage"] = services.NewSoftLayer_Network_Storage_Service(slc)
+	slc.softLayerServices["SoftLayer_Network_Storage_Allowed_Host"] = services.NewSoftLayer_Network_Storage_Allowed_Host_Service(slc)
+	slc.softLayerServices["SoftLayer_Product_Order"] = services.NewSoftLayer_Product_Order_Service(slc)
+	slc.softLayerServices["SoftLayer_Billing_Item_Cancellation_Request"] = services.NewSoftLayer_Billing_Item_Cancellation_Request_Service(slc)
+	slc.softLayerServices["SoftLayer_Billing_Item"] = services.NewSoftLayer_Billing_Item_Service(slc)
+	slc.softLayerServices["SoftLayer_Virtual_Guest_Block_Device_Template_Group"] = services.NewSoftLayer_Virtual_Guest_Block_Device_Template_Group_Service(slc)
+	slc.softLayerServices["SoftLayer_Hardware"] = services.NewSoftLayer_Hardware_Service(slc)
+	slc.softLayerServices["SoftLayer_Dns_Domain"] = services.NewSoftLayer_Dns_Domain_Service(slc)
+	slc.softLayerServices["SoftLayer_Dns_Domain_ResourceRecord"] = services.NewSoftLayer_Dns_Domain_ResourceRecord_Service(slc)
+	slc.softLayerServices["SoftLayer_Network_Application_Delivery_Controller_Service"] = services.NewSoftLayer_Network_Application_Delivery_Controller_Service(slc)
+	slc.softLayerServices["SoftLayer_Security_Certificate"] = services.NewSoftLayer_Security_Certificate_Service(slc)
+}
+
+func (slc *SoftLayerClient) makeHttpRequest(url string, requestType string, requestBody *bytes.Buffer) ([]byte, error) {
+	req, err := http.NewRequest(requestType, url, requestBody)
+	if err != nil {
+		return nil, err
+	}
+
+	bs, err := httputil.DumpRequest(req, true)
+	if err != nil {
+		return nil, err
+	}
+
+	if !slc.nonVerbose {
+		fmt.Fprintf(os.Stderr, "\n---\n[softlayer-go] Request:\n%s\n", hideCredentials(string(bs)))
+	}
+
+	resp, err := slc.HTTPClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	bs, err = httputil.DumpResponse(resp, true)
+	if err != nil {
+		return nil, err
+	}
+
+	if !slc.nonVerbose {
+		fmt.Fprintf(os.Stderr, "[softlayer-go] Response:\n%s\n", hideCredentials(string(bs)))
+	}
+
+	responseBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	return responseBody, nil
+}
+
+//Private helper methods

--- a/vendor/github.com/TheWeatherCompany/softlayer-go/common/utility.go
+++ b/vendor/github.com/TheWeatherCompany/softlayer-go/common/utility.go
@@ -1,0 +1,24 @@
+package common
+
+import (
+	"encoding/json"
+)
+
+func ValidateJson(s string) (bool, error) {
+	var js map[string]interface{}
+
+	err := json.Unmarshal([]byte(s), &js)
+	if err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
+func IsHttpErrorCode(errorCode int) bool {
+	if errorCode >= 400 {
+		return true
+	}
+
+	return false
+}

--- a/vendor/github.com/TheWeatherCompany/softlayer-go/data_types/softLayer_network_storage_credential.go
+++ b/vendor/github.com/TheWeatherCompany/softlayer-go/data_types/softLayer_network_storage_credential.go
@@ -1,0 +1,14 @@
+package data_types
+
+import (
+	"time"
+)
+
+type SoftLayer_Network_Storage_Credential struct {
+	AccountId           string    `json:"accountId"`
+	CreateDate          time.Time `json:"createDate"`
+	Id                  int       `json:"Id"`
+	NasCredentialTypeId int       `json:"nasCredentialTypeId"`
+	Password            string    `json:"password"`
+	Username            string    `json:"username"`
+}

--- a/vendor/github.com/TheWeatherCompany/softlayer-go/data_types/softLayer_tag_reference.go
+++ b/vendor/github.com/TheWeatherCompany/softlayer-go/data_types/softLayer_tag_reference.go
@@ -1,0 +1,24 @@
+package data_types
+
+type SoftLayer_Tag_Reference struct {
+	EmpRecordId     *int         `json:"empRecordId"`
+	Id              int          `json:"id"`
+	ResourceTableId int          `json:"resourceTableId"`
+	Tag             TagReference `json:"tag"`
+	TagId           int          `json:"tagId"`
+	TagType         TagType      `json:"tagType"`
+	TagTypeId       int          `json:"tagTypeId"`
+	UsrRecordId     int          `json:"usrRecordId"`
+}
+
+type TagReference struct {
+	AccountId int    `json:"accountId"`
+	Id        int    `json:"id"`
+	Internal  int    `json:"internal"`
+	Name      string `json:"name"`
+}
+
+type TagType struct {
+	Description string `json:"description"`
+	KeyName     string `json:"keyName"`
+}

--- a/vendor/github.com/TheWeatherCompany/softlayer-go/data_types/softLayer_virtual_guest_attribute.go
+++ b/vendor/github.com/TheWeatherCompany/softlayer-go/data_types/softLayer_virtual_guest_attribute.go
@@ -1,0 +1,12 @@
+package data_types
+
+type SoftLayer_Virtual_Guest_Attribute_Type struct {
+	Keyname string `json:"keyname"`
+	Name    string `json:"name"`
+}
+
+type SoftLayer_Virtual_Guest_Attribute struct {
+	Value string `json:"value"`
+
+	Type SoftLayer_Virtual_Guest_Attribute_Type `json:"type"`
+}

--- a/vendor/github.com/TheWeatherCompany/softlayer-go/data_types/softLayer_virtual_guest_block_device_template_group_init_parameters.go
+++ b/vendor/github.com/TheWeatherCompany/softlayer-go/data_types/softLayer_virtual_guest_block_device_template_group_init_parameters.go
@@ -1,0 +1,21 @@
+package data_types
+
+type SoftLayer_Virtual_Guest_Block_Device_Template_GroupInitParameters struct {
+	Parameters SoftLayer_Virtual_Guest_Block_Device_Template_GroupInitParameter `json:"parameters"`
+}
+
+type SoftLayer_Virtual_Guest_Block_Device_Template_GroupInitParameter struct {
+	AccountId int `json:"accountId"`
+}
+
+type SoftLayer_Virtual_Guest_Block_Device_Template_Group_LocationsInitParameters struct {
+	Parameters SoftLayer_Virtual_Guest_Block_Device_Template_Group_LocationsInitParameter `json:"parameters"`
+}
+
+type SoftLayer_Virtual_Guest_Block_Device_Template_Group_LocationsInitParameter struct {
+	Locations []SoftLayer_Location `json:"locations"`
+}
+
+type SoftLayer_Virtual_Guest_Block_Device_Template_GroupInitParameters2 struct {
+	Parameters []interface{} `json:"parameters"`
+}

--- a/vendor/github.com/TheWeatherCompany/softlayer-go/data_types/softLayer_virtual_guest_block_device_template_group_status.go
+++ b/vendor/github.com/TheWeatherCompany/softlayer-go/data_types/softLayer_virtual_guest_block_device_template_group_status.go
@@ -1,0 +1,7 @@
+package data_types
+
+type SoftLayer_Virtual_Guest_Block_Device_Template_Group_Status struct {
+	Description string `json:"description"`
+	KeyName     string `json:"keyName"`
+	Name        string `json:"name"`
+}

--- a/vendor/github.com/TheWeatherCompany/softlayer-go/data_types/softlayer_account_status.go
+++ b/vendor/github.com/TheWeatherCompany/softlayer-go/data_types/softlayer_account_status.go
@@ -1,0 +1,6 @@
+package data_types
+
+type SoftLayer_Account_Status struct {
+	Id   int    `json:"id"`
+	Name string `json:"name"`
+}

--- a/vendor/github.com/TheWeatherCompany/softlayer-go/data_types/softlayer_billing_item.go
+++ b/vendor/github.com/TheWeatherCompany/softlayer-go/data_types/softlayer_billing_item.go
@@ -1,0 +1,30 @@
+package data_types
+
+import (
+	"time"
+)
+
+type SoftLayer_Billing_Item struct {
+	Id                    int        `json:"id"`
+	AllowCancellationFlag int        `json:"allowCancellationFlag,omitempty"`
+	CancellationDate      *time.Time `json:"cancellationDate,omitempty"`
+	CategoryCode          string     `json:"categoryCode,omitempty"`
+	CycleStartDate        *time.Time `json:"cycleStartDate,omitempty"`
+	CreateDate            *time.Time `json:"createDate,omitempty"`
+	Description           string     `json:"description,omitempty"`
+	LaborFee              string     `json:"laborFee,omitempty"`
+	LaborFeeTaxRate       string     `json:"laborFeeTaxRate,omitempty"`
+	LastBillDate          *time.Time `json:"lastBillDate,omitempty"`
+	ModifyDate            *time.Time `json:"modifyDate,omitempty"`
+	NextBillDate          *time.Time `json:"nextBillDate,omitempty"`
+	OneTimeFee            string     `json:"oneTimeFee,omitempty"`
+	OneTimeFeeTaxRate     string     `json:"oneTimeFeeTaxRate,omitempty"`
+	OrderItemId           int        `json:"orderItemId,omitempty"`
+	ParentId              int        `json:"parentId,omitempty"`
+	RecurringFee          string     `json:"recurringFee,omitempty"`
+	RecurringFeeTaxRate   string     `json:"recurringFeeTaxRate,omitempty"`
+	RecurringMonths       int        `json:"recurringMonths,omitempty"`
+	ServiceProviderId     int        `json:"serviceProviderId,omitempty"`
+	SetupFee              string     `json:"setupFee,omitempty"`
+	SetupFeeTaxRate       string     `json:"setupFeeTaxRate,omitempty"`
+}

--- a/vendor/github.com/TheWeatherCompany/softlayer-go/data_types/softlayer_billing_item_cancellation_request.go
+++ b/vendor/github.com/TheWeatherCompany/softlayer-go/data_types/softlayer_billing_item_cancellation_request.go
@@ -1,0 +1,18 @@
+package data_types
+
+type SoftLayer_Billing_Item_Cancellation_Request_Parameters struct {
+	Parameters []SoftLayer_Billing_Item_Cancellation_Request `json:"parameters"`
+}
+
+type SoftLayer_Billing_Item_Cancellation_Request struct {
+	ComplexType string                                             `json:"complexType"`
+	AccountId   int                                                `json:"accountId"`
+	Id          int                                                `json:"id"`
+	TicketId    int                                                `json:"ticketId"`
+	Items       []SoftLayer_Billing_Item_Cancellation_Request_Item `json:"items"`
+}
+
+type SoftLayer_Billing_Item_Cancellation_Request_Item struct {
+	BillingItemId             int  `json:"billingItemId"`
+	ImmediateCancellationFlag bool `json:"immediateCancellationFlag"`
+}

--- a/vendor/github.com/TheWeatherCompany/softlayer-go/data_types/softlayer_container_disk_image_capture_template.go
+++ b/vendor/github.com/TheWeatherCompany/softlayer-go/data_types/softlayer_container_disk_image_capture_template.go
@@ -1,0 +1,17 @@
+package data_types
+
+type SoftLayer_Container_Disk_Image_Capture_Template struct {
+	Description string                                                   `json:"description"`
+	Name        string                                                   `json:"name"`
+	Summary     string                                                   `json:"summary"`
+	Volumes     []SoftLayer_Container_Disk_Image_Capture_Template_Volume `json:"volumes"`
+}
+
+type SoftLayer_Container_Disk_Image_Capture_Template_Volume struct {
+	Name       string `json:"name"`
+	Partitions []SoftLayer_Container_Disk_Image_Capture_Template_Volume_Partition
+}
+
+type SoftLayer_Container_Disk_Image_Capture_Template_Volume_Partition struct {
+	Name string `json:"name"`
+}

--- a/vendor/github.com/TheWeatherCompany/softlayer-go/data_types/softlayer_container_product_order.go
+++ b/vendor/github.com/TheWeatherCompany/softlayer-go/data_types/softlayer_container_product_order.go
@@ -1,0 +1,74 @@
+package data_types
+
+type SoftLayer_Container_Product_Order_Receipt struct {
+	OrderId int `json:"orderId"`
+}
+
+type SoftLayer_Container_Product_Order_Parameters struct {
+	Parameters []SoftLayer_Container_Product_Order `json:"parameters"`
+}
+
+type SoftLayer_Container_Product_Order_Network_PerformanceStorage_Iscsi_Parameters struct {
+	Parameters []SoftLayer_Container_Product_Order_Network_PerformanceStorage_Iscsi `json:"parameters"`
+}
+
+type SoftLayer_Container_Product_Order_Virtual_Guest_Upgrade_Parameters struct {
+	Parameters []SoftLayer_Container_Product_Order_Virtual_Guest_Upgrade `json:"parameters"`
+}
+
+type SoftLayer_Container_Product_Order_Network_Application_Delivery_Controller_Parameters struct {
+	Parameters []SoftLayer_Container_Product_Order_Network_Application_Delivery_Controller `json:"parameters"`
+}
+
+//http://sldn.softlayer.com/reference/datatypes/SoftLayer_Container_Product_Order
+type SoftLayer_Container_Product_Order struct {
+	ComplexType   string                         `json:"complexType"`
+	Location      string                         `json:"location,omitempty"`
+	PackageId     int                            `json:"packageId"`
+	Prices        []SoftLayer_Product_Item_Price `json:"prices,omitempty"`
+	VirtualGuests []VirtualGuest                 `json:"virtualGuests,omitempty"`
+	Properties    []Property                     `json:"properties,omitempty"`
+	Quantity      int                            `json:"quantity,omitempty"`
+}
+
+//http://sldn.softlayer.com/reference/datatypes/SoftLayer_Container_Product_Order_Network_PerformanceStorage_Iscsi
+type SoftLayer_Container_Product_Order_Network_PerformanceStorage_Iscsi struct {
+	ComplexType   string                                  `json:"complexType"`
+	Location      string                                  `json:"location,omitempty"`
+	PackageId     int                                     `json:"packageId"`
+	Prices        []SoftLayer_Product_Item_Price          `json:"prices,omitempty"`
+	VirtualGuests []VirtualGuest                          `json:"virtualGuests,omitempty"`
+	Properties    []Property                              `json:"properties,omitempty"`
+	Quantity      int                                     `json:"quantity,omitempty"`
+	OsFormatType  SoftLayer_Network_Storage_Iscsi_OS_Type `json:"osFormatType,omitempty"`
+}
+
+//http://sldn.softlayer.com/reference/datatypes/SoftLayer_Container_Product_Order_Virtual_Guest_Upgrade
+type SoftLayer_Container_Product_Order_Virtual_Guest_Upgrade struct {
+	ComplexType   string                         `json:"complexType"`
+	Location      string                         `json:"location,omitempty"`
+	PackageId     int                            `json:"packageId"`
+	Prices        []SoftLayer_Product_Item_Price `json:"prices,omitempty"`
+	VirtualGuests []VirtualGuest                 `json:"virtualGuests,omitempty"`
+	Properties    []Property                     `json:"properties,omitempty"`
+	Quantity      int                            `json:"quantity,omitempty"`
+}
+
+//http://sldn.softlayer.com/reference/datatypes/SoftLayer_Container_Product_Order_Network_Application_Delivery_Controller
+type SoftLayer_Container_Product_Order_Network_Application_Delivery_Controller struct {
+	ComplexType string                         `json:"complexType"`
+	Location    string                         `json:"location,omitempty"`
+	PackageId   int                            `json:"packageId"`
+	Prices      []SoftLayer_Product_Item_Price `json:"prices,omitempty"`
+	Properties  []Property                     `json:"properties,omitempty"`
+	Quantity    int                            `json:"quantity,omitempty"`
+}
+
+type Property struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+type VirtualGuest struct {
+	Id int `json:"id"`
+}

--- a/vendor/github.com/TheWeatherCompany/softlayer-go/data_types/softlayer_container_virtual_guest_block_device_template_configuration.go
+++ b/vendor/github.com/TheWeatherCompany/softlayer-go/data_types/softlayer_container_virtual_guest_block_device_template_configuration.go
@@ -1,0 +1,12 @@
+package data_types
+
+type SoftLayer_Container_Virtual_Guest_Block_Device_Template_Configuration_Parameters struct {
+	Parameters []SoftLayer_Container_Virtual_Guest_Block_Device_Template_Configuration `json:"parameters"`
+}
+
+type SoftLayer_Container_Virtual_Guest_Block_Device_Template_Configuration struct {
+	Name                         string `json:"name"`
+	Note                         string `json:"note"`
+	OperatingSystemReferenceCode string `json:"operatingSystemReferenceCode"`
+	Uri                          string `json:"uri"`
+}

--- a/vendor/github.com/TheWeatherCompany/softlayer-go/data_types/softlayer_dns_domain.go
+++ b/vendor/github.com/TheWeatherCompany/softlayer-go/data_types/softlayer_dns_domain.go
@@ -1,0 +1,20 @@
+package data_types
+
+type SoftLayer_Dns_Domain_Template struct {
+	Name            string                                `json:"name"`
+	ResourceRecords []SoftLayer_Dns_Domain_ResourceRecord `json:"resourceRecords"`
+}
+
+type SoftLayer_Dns_Domain_Template_Parameters struct {
+	Parameters []SoftLayer_Dns_Domain_Template `json:"parameters"`
+}
+
+type SoftLayer_Dns_Domain struct {
+	Id                  int                                   `json:"id"`
+	Name                string                                `json:"name"`
+	Serial              int                                   `json:"serial"`
+	UpdateDate          string                                `json:"updateDate"`
+	ManagedResourceFlag bool                                  `json:"managedResourceFlag"`
+	ResourceRecordCount int                                   `json:"resourceRecordCount"`
+	ResourceRecords     []SoftLayer_Dns_Domain_ResourceRecord `json:"resourceRecords"`
+}

--- a/vendor/github.com/TheWeatherCompany/softlayer-go/data_types/softlayer_dns_domain_record.go
+++ b/vendor/github.com/TheWeatherCompany/softlayer-go/data_types/softlayer_dns_domain_record.go
@@ -1,0 +1,49 @@
+package data_types
+
+type SoftLayer_Dns_Domain_ResourceRecord_Template_Parameters struct {
+	Parameters []SoftLayer_Dns_Domain_ResourceRecord_Template `json:"parameters"`
+}
+
+type SoftLayer_Dns_Domain_ResourceRecord_Template struct {
+	Data              string `json:"data"`
+	DomainId          int    `json:"domainId"`
+	Expire            int    `json:"expire"`
+	Host              string `json:"host"`
+	Id                int    `json:"id"`
+	Minimum           int    `json:"minimum"`
+	MxPriority        int    `json:"mxPriority"`
+	Refresh           int    `json:"refresh"`
+	ResponsiblePerson string `json:"responsiblePerson"`
+	Retry             int    `json:"retry"`
+	Ttl               int    `json:"ttl"`
+	Type              string `json:"type"`
+	Service           string `json:"service,omitempty"`
+	Protocol          string `json:"protocol,omitempty"`
+	Priority          int    `json:"priority,omitempty"`
+	Port              int    `json:"port,omitempty"`
+	Weight            int    `json:"weight,omitempty"`
+}
+
+type SoftLayer_Dns_Domain_ResourceRecord_Parameters struct {
+	Parameters []SoftLayer_Dns_Domain_ResourceRecord `json:"parameters"`
+}
+
+type SoftLayer_Dns_Domain_ResourceRecord struct {
+	Data              string `json:"data"`
+	DomainId          int    `json:"domainId"`
+	Expire            int    `json:"expire"`
+	Host              string `json:"host"`
+	Id                int    `json:"id"`
+	Minimum           int    `json:"minimum"`
+	MxPriority        int    `json:"mxPriority"`
+	Refresh           int    `json:"refresh"`
+	ResponsiblePerson string `json:"responsiblePerson"`
+	Retry             int    `json:"retry"`
+	Ttl               int    `json:"ttl"`
+	Type              string `json:"type"`
+	Service           string `json:"service,omitempty"`
+	Protocol          string `json:"protocol,omitempty"`
+	Priority          int    `json:"priority,omitempty"`
+	Port              int    `json:"port,omitempty"`
+	Weight            int    `json:"weight,omitempty"`
+}

--- a/vendor/github.com/TheWeatherCompany/softlayer-go/data_types/softlayer_hardware.go
+++ b/vendor/github.com/TheWeatherCompany/softlayer-go/data_types/softlayer_hardware.go
@@ -1,0 +1,44 @@
+package data_types
+
+import (
+	"time"
+)
+
+type SoftLayer_Hardware_Template_Parameters struct {
+	Parameters []SoftLayer_Hardware_Template `json:"parameters"`
+}
+
+type SoftLayer_Hardware_Template struct {
+	Hostname                     string `json:"hostname"`
+	Domain                       string `json:"domain"`
+	ProcessorCoreAmount          int    `json:"processorCoreAmount"`
+	MemoryCapacity               int    `json:"memoryCapacity"`
+	HourlyBillingFlag            bool   `json:"hourlyBillingFlag"`
+	OperatingSystemReferenceCode string `json:"operatingSystemReferenceCode"`
+
+	Datacenter *Datacenter `json:"datacenter"`
+}
+
+type SoftLayer_Hardware struct {
+	BareMetalInstanceFlag int        `json:"bareMetalInstanceFlag"`
+	Domain                string     `json:"domain"`
+	Hostname              string     `json:"hostname"`
+	Id                    int        `json:"id"`
+	HardwareStatusId      int        `json:"hardwareStatusId"`
+	ProvisionDate         *time.Time `json:"provisionDate"`
+	GlobalIdentifier      string     `json:"globalIdentifier"`
+	PrimaryIpAddress      string     `json:"primaryIpAddress"`
+
+	OperatingSystem *SoftLayer_Operating_System `json:"operatingSystem"`
+
+	Location   *SoftLayer_Location `json:"location"`
+	Datacenter *SoftLayer_Location `json:"datacenter"`
+}
+
+type SoftLayer_Hardware_String_Parameters struct {
+	Parameters []string `json:"parameters"`
+}
+
+type SoftLayer_Hardware_NetworkStorage_Parameters struct {
+	Parameters SoftLayer_Network_Storage `json:"parameters"`
+}

--- a/vendor/github.com/TheWeatherCompany/softlayer-go/data_types/softlayer_image_type.go
+++ b/vendor/github.com/TheWeatherCompany/softlayer-go/data_types/softlayer_image_type.go
@@ -1,0 +1,7 @@
+package data_types
+
+type SoftLayer_Image_Type struct {
+	Description string `json:"description"`
+	KeyName     string `json:"keyName"`
+	Name        string `json:"name"`
+}

--- a/vendor/github.com/TheWeatherCompany/softlayer-go/data_types/softlayer_location.go
+++ b/vendor/github.com/TheWeatherCompany/softlayer-go/data_types/softlayer_location.go
@@ -1,0 +1,7 @@
+package data_types
+
+type SoftLayer_Location struct {
+	Id       int    `json:"id"`
+	LongName string `json:"longName"`
+	Name     string `json:"name"`
+}

--- a/vendor/github.com/TheWeatherCompany/softlayer-go/data_types/softlayer_network_application_delivery_controller.go
+++ b/vendor/github.com/TheWeatherCompany/softlayer-go/data_types/softlayer_network_application_delivery_controller.go
@@ -1,0 +1,31 @@
+package data_types
+
+type SoftLayer_Network_Application_Delivery_Controller struct {
+	Id                    int                       `json:"id"`
+	Name                  string                    `json:"name"`
+	TypeId                int                       `json:"typeId"`
+	ModifyDate            string                    `json:"modifyDate"`
+	CreateDate            string                    `json:"createDate"`
+	Description           string                    `json:"description"`
+	ManagedResourceFlag   bool                      `json:"managedResourceFlag"`
+	ManagementIpAddress   string                    `json:"managementIpAddress"`
+	PrimaryIpAddress      string                    `json:"primaryIpAddress"`
+	Password              SoftLayer_Password        `json:"password"`
+	Notes                 string                    `json:"notes"`
+	Datacenter            *SoftLayer_Location       `json:"datacenter"`
+	NetworkVlan           *SoftLayer_Network_Vlan   `json:"networkVlan"`
+	NetworkVlanCount      int                       `json:"networkVlanCount"`
+	NetworkVlans          []SoftLayer_Network_Vlan  `json:"networkVlans"`
+	TagReferenceCount     int                       `json:"tagReferenceCount"`
+	TagReferences         []SoftLayer_Tag_Reference `json:"tagReferences"`
+	VirtualAddressCount   int                       `json:"virtualIpAddressCount"`
+	SubnetCount           int                       `json:"subnetCount"`
+	LicenseExpirationDate string                    `json:"licenseExpirationDate"`
+
+	Type *SoftLayer_Network_Application_Delivery_Controller_Type `json:"type"`
+}
+
+type SoftLayer_Network_Application_Delivery_Controller_Type struct {
+	KeyName string `json:"keyName"`
+	Name    string `json:"name"`
+}

--- a/vendor/github.com/TheWeatherCompany/softlayer-go/data_types/softlayer_network_load_balancer_service.go
+++ b/vendor/github.com/TheWeatherCompany/softlayer-go/data_types/softlayer_network_load_balancer_service.go
@@ -1,0 +1,41 @@
+package data_types
+
+type SoftLayer_Network_LoadBalancer_Service struct {
+	Name                 string `json:"name"`
+	DestinationIpAddress string `json:"destinationIpAddress"`
+	DestinationPort      int    `json:"destinationPort"`
+	Weight               int    `json:"weight"`
+	HealthCheck          string `json:"healthCheck"`
+	ConnectionLimit      int    `json:"connectionLimit"`
+}
+
+type SoftLayer_Network_LoadBalancer_Service_Parameters struct {
+	Parameters []SoftLayer_Network_LoadBalancer_Service_VipName_Services `json:"parameters"`
+}
+
+type SoftLayer_Network_LoadBalancer_Service_VipName_Services struct {
+	VipName  string                                            `json:"name"`
+	Services []SoftLayer_Network_LoadBalancer_Service_Template `json:"services"`
+}
+
+type SoftLayer_Network_LoadBalancer_Service_Parameters_Delete struct {
+	Parameters []SoftLayer_Network_LoadBalancer_Service_VipName_Services_Delete `json:"parameters"`
+}
+
+type SoftLayer_Network_LoadBalancer_Service_VipName_Services_Delete struct {
+	ServiceName string                                         `json:"name"`
+	Vip         SoftLayer_Network_LoadBalancer_Service_VipName `json:"vip"`
+}
+
+type SoftLayer_Network_LoadBalancer_Service_VipName struct {
+	VipName string `json:"name"`
+}
+
+type SoftLayer_Network_LoadBalancer_Service_Template struct {
+	Name                 string `json:"name"`
+	DestinationIpAddress string `json:"destinationIpAddress"`
+	DestinationPort      int    `json:"destinationPort"`
+	Weight               int    `json:"weight"`
+	HealthCheck          string `json:"healthCheck"`
+	ConnectionLimit      int    `json:"connectionLimit"`
+}

--- a/vendor/github.com/TheWeatherCompany/softlayer-go/data_types/softlayer_network_load_balancer_virtual_ip_address.go
+++ b/vendor/github.com/TheWeatherCompany/softlayer-go/data_types/softlayer_network_load_balancer_virtual_ip_address.go
@@ -1,0 +1,33 @@
+package data_types
+
+type SoftLayer_Network_LoadBalancer_VirtualIpAddress_Array []SoftLayer_Network_LoadBalancer_VirtualIpAddress
+
+type SoftLayer_Network_LoadBalancer_VirtualIpAddress struct {
+	Id                          int                                      `json:"id"`
+	ConnectionLimit             int                                      `json:"connectionLimit"`
+	CustomManagedFlag           bool                                     `json:"customManagedFlag"`
+	LoadBalancingMethod         string                                   `json:"loadBalancingMethod"`
+	LoadBalancingMethodFullName string                                   `json:"loadBalancingMethodFullName"`
+	ModifyDate                  string                                   `json:"modifyDate"`
+	Name                        string                                   `json:"name"`
+	SecurityCertificateId       int                                      `json:"securityCertificateId"`
+	SourcePort                  int                                      `json:"sourcePort"`
+	Type                        string                                   `json:"type"`
+	VirtualIpAddress            string                                   `json:"virtualIpAddress"`
+	Services                    []SoftLayer_Network_LoadBalancer_Service `json:"services"`
+}
+
+type SoftLayer_Network_LoadBalancer_VirtualIpAddress_Template_Parameters struct {
+	Parameters []SoftLayer_Network_LoadBalancer_VirtualIpAddress_Template `json:"parameters"`
+}
+
+type SoftLayer_Network_LoadBalancer_VirtualIpAddress_Template struct {
+	Id                    int    `json:"id"`
+	ConnectionLimit       int    `json:"connectionLimit"`
+	LoadBalancingMethod   string `json:"loadBalancingMethod"`
+	Name                  string `json:"name"`
+	SecurityCertificateId int    `json:"securityCertificateId"`
+	SourcePort            int    `json:"sourcePort"`
+	Type                  string `json:"type"`
+	VirtualIpAddress      string `json:"virtualIpAddress"`
+}

--- a/vendor/github.com/TheWeatherCompany/softlayer-go/data_types/softlayer_network_storage.go
+++ b/vendor/github.com/TheWeatherCompany/softlayer-go/data_types/softlayer_network_storage.go
@@ -1,0 +1,37 @@
+package data_types
+
+import (
+	"time"
+)
+
+type SoftLayer_Network_Storage struct {
+	AccountId                       int           `json:"accountId,omitempty"`
+	CapacityGb                      int           `json:"capacityGb,omitempty"`
+	CreateDate                      time.Time     `json:"createDate,omitempty"`
+	GuestId                         int           `json:"guestId,omitempty"`
+	HardwareId                      int           `json:"hardwareId,omitempty"`
+	HostId                          int           `json:"hostId,omitempty"`
+	Id                              int           `json:"id,omitempty"`
+	NasType                         string        `json:"nasType,omitempty"`
+	Notes                           string        `json:"notes,omitempty"`
+	Password                        string        `json:"password,omitempty"`
+	ServiceProviderId               int           `json:"serviceProviderId,omitempty"`
+	UpgradableFlag                  bool          `json:"upgradableFlag,omitempty"`
+	Username                        string        `json:"username,omitempty"`
+	BillingItem                     *Billing_Item `json:"billingItem,omitempty"`
+	LunId                           string        `json:"lunId,omitempty"`
+	ServiceResourceBackendIpAddress string        `json:"serviceResourceBackendIpAddress,omitempty"`
+}
+
+type Billing_Item struct {
+	Id        int         `json:"id,omitempty"`
+	OrderItem *Order_Item `json:"orderItem,omitempty"`
+}
+
+type Order_Item struct {
+	Order *Order `json:"order,omitempty"`
+}
+
+type Order struct {
+	Id int `json:"id,omitempty"`
+}

--- a/vendor/github.com/TheWeatherCompany/softlayer-go/data_types/softlayer_network_storage_allowed_host.go
+++ b/vendor/github.com/TheWeatherCompany/softlayer-go/data_types/softlayer_network_storage_allowed_host.go
@@ -1,0 +1,9 @@
+package data_types
+
+type SoftLayer_Network_Storage_Allowed_Host struct {
+	CredentialId      int    `json:"credentialId"`
+	Id                int    `json:"id"`
+	Name              string `json:"name"`
+	ResourceTableId   int    `json:"resourceTabledId"`
+	ResourceTableName string `jsob:"resourceTableName"`
+}

--- a/vendor/github.com/TheWeatherCompany/softlayer-go/data_types/softlayer_network_storage_iscsi_os_type.go
+++ b/vendor/github.com/TheWeatherCompany/softlayer-go/data_types/softlayer_network_storage_iscsi_os_type.go
@@ -1,0 +1,12 @@
+package data_types
+
+import (
+	"time"
+)
+
+type SoftLayer_Network_Storage_Iscsi_OS_Type struct {
+	CreateDate time.Time `json:"createDate"`
+	Id         int       `json:"id"`
+	Name       string    `json:"name"`
+	KeyName    string    `json:"keyName"`
+}

--- a/vendor/github.com/TheWeatherCompany/softlayer-go/data_types/softlayer_network_vlan.go
+++ b/vendor/github.com/TheWeatherCompany/softlayer-go/data_types/softlayer_network_vlan.go
@@ -1,0 +1,16 @@
+package data_types
+
+import (
+	"time"
+)
+
+type SoftLayer_Network_Vlan struct {
+	AccountId       int        `json:"accountId"`
+	Id              int        `json:"Id"`
+	ModifyDate      *time.Time `json:"modifyDate,omitempty"`
+	Name            string     `json:"name"`
+	NetworkVrfId    int        `json:"networkVrfId"`
+	Note            string     `json:"note"`
+	PrimarySubnetId int        `json:"primarySubnetId"`
+	VlanNumber      int        `json:"vlanNumber"`
+}

--- a/vendor/github.com/TheWeatherCompany/softlayer-go/data_types/softlayer_product_item_price.go
+++ b/vendor/github.com/TheWeatherCompany/softlayer-go/data_types/softlayer_product_item_price.go
@@ -1,0 +1,19 @@
+package data_types
+
+type SoftLayer_Product_Item_Price struct {
+	Id              int        `json:"id"`
+	LocationGroupId int        `json:"locationGroupId"`
+	Categories      []Category `json:"categories,omitempty"`
+	Item            *Item      `json:"item,omitempty"`
+}
+
+type Item struct {
+	Id          int    `json:"id"`
+	Description string `json:"description"`
+	Capacity    string `json:"capacity"`
+}
+
+type Category struct {
+	Id           int    `json:"id"`
+	CategoryCode string `json:"categoryCode"`
+}

--- a/vendor/github.com/TheWeatherCompany/softlayer-go/data_types/softlayer_product_package.go
+++ b/vendor/github.com/TheWeatherCompany/softlayer-go/data_types/softlayer_product_package.go
@@ -1,0 +1,22 @@
+package data_types
+
+type Softlayer_Product_Package struct {
+	Id          int           `json:"id"`
+	Name        string        `json:"name"`
+	IsActive    int           `json:"isActive"`
+	Description string        `json:"description"`
+	PackageType *Package_Type `json:"type"`
+}
+
+type Package_Type struct {
+	KeyName string `json:"keyName"`
+}
+
+type SoftLayer_Product_Item struct {
+	Id          int                            `json:"id"`
+	Description string                         `json:"description"`
+	Capacity    string                         `json:"capacity"`
+	Units       string                         `json:"units,omitempty"`
+	Key         string                         `json:"keyName"`
+	Prices      []SoftLayer_Product_Item_Price `json:"prices,omitempty"`
+}

--- a/vendor/github.com/TheWeatherCompany/softlayer-go/data_types/softlayer_provisioning_version1_transaction.go
+++ b/vendor/github.com/TheWeatherCompany/softlayer-go/data_types/softlayer_provisioning_version1_transaction.go
@@ -1,0 +1,29 @@
+package data_types
+
+import (
+	"time"
+)
+
+type TransactionGroup struct {
+	AverageTimeToComplete string `json:"averageTimeToComplete"`
+	Name                  string `json:"name"`
+}
+
+type TransactionStatus struct {
+	AverageDuration string `json:"averageDuration"`
+	FriendlyName    string `json:"friendlyName"`
+	Name            string `json:"name"`
+}
+
+type SoftLayer_Provisioning_Version1_Transaction struct {
+	CreateDate       *time.Time `json:"createDate"`
+	ElapsedSeconds   int        `json:"elapsedSeconds"`
+	GuestId          int        `json:"guestId"`
+	HardwareId       int        `json:"hardwareId"`
+	Id               int        `json:"id"`
+	ModifyDate       *time.Time `json:"modifyDate"`
+	StatusChangeDate *time.Time `json:"statusChangeDate"`
+
+	TransactionGroup  TransactionGroup  `json:"transactionGroup,omitempty"`
+	TransactionStatus TransactionStatus `json:"transactionStatus,omitempty"`
+}

--- a/vendor/github.com/TheWeatherCompany/softlayer-go/data_types/softlayer_security_certificate.go
+++ b/vendor/github.com/TheWeatherCompany/softlayer-go/data_types/softlayer_security_certificate.go
@@ -1,0 +1,26 @@
+package data_types
+
+type SoftLayer_Security_Certificate struct {
+	Id                      int    `json:"id"`
+	Certificate             string `json:"certificate"`
+	IntermediateCertificate string `json:"intermediateCertificate"`
+	PrivateKey              string `json:"privateKey"`
+	CommonName              string `json:"commonName"`
+	OrganizationName        string `json:"organizationName"`
+	ValidityBegin           string `json:"validityBegin"`
+	ValidityDays            int    `json:"validityDays"`
+	ValidityEnd             string `json:"validityEnd"`
+	KeySize                 int    `json:"keySize"`
+	CreateDate              string `json:"createDate"`
+	ModifyDate              string `json:"modifyDate"`
+}
+
+type SoftLayer_Security_Certificate_Parameters struct {
+	Parameters []SoftLayer_Security_Certificate_Template `json:"parameters"`
+}
+
+type SoftLayer_Security_Certificate_Template struct {
+	Certificate             string `json:"certificate"`
+	IntermediateCertificate string `json:"intermediateCertificate"`
+	PrivateKey              string `json:"privateKey"`
+}

--- a/vendor/github.com/TheWeatherCompany/softlayer-go/data_types/softlayer_security_ssh_key.go
+++ b/vendor/github.com/TheWeatherCompany/softlayer-go/data_types/softlayer_security_ssh_key.go
@@ -1,0 +1,19 @@
+package data_types
+
+import (
+	"time"
+)
+
+type SoftLayer_Shh_Key_Parameters struct {
+	Parameters []SoftLayer_Security_Ssh_Key `json:"parameters"`
+}
+
+type SoftLayer_Security_Ssh_Key struct {
+	CreateDate  *time.Time `json:"createDate"`
+	Fingerprint string     `json:"fingerprint"`
+	Id          int        `json:"id"`
+	Key         string     `json:"key"`
+	Label       string     `json:"label"`
+	ModifyDate  *time.Time `json:"modifyDate"`
+	Notes       string     `json:"notes"`
+}

--- a/vendor/github.com/TheWeatherCompany/softlayer-go/data_types/softlayer_set_user_metadata.go
+++ b/vendor/github.com/TheWeatherCompany/softlayer-go/data_types/softlayer_set_user_metadata.go
@@ -1,0 +1,8 @@
+package data_types
+
+type UserMetadata string
+type UserMetadataArray []UserMetadata
+
+type SoftLayer_SetUserMetadata_Parameters struct {
+	Parameters []UserMetadataArray `json:"parameters"`
+}

--- a/vendor/github.com/TheWeatherCompany/softlayer-go/data_types/softlayer_software_component_password.go
+++ b/vendor/github.com/TheWeatherCompany/softlayer-go/data_types/softlayer_software_component_password.go
@@ -1,0 +1,24 @@
+package data_types
+
+import (
+	"time"
+)
+
+type Software struct {
+	HardwareId                  int    `json:"hardwareId,omitempty"`
+	Id                          int    `json:"id"`
+	ManufacturerLicenseInstance string `json:"manufacturerLicenseInstance"`
+}
+
+type SoftLayer_Software_Component_Password struct {
+	CreateDate *time.Time `json:"createDate"`
+	Id         int        `json:"id"`
+	ModifyDate *time.Time `json:"modifyDate"`
+	Notes      string     `json:"notes"`
+	Password   string     `json:"password"`
+	Port       int        `json:"port"`
+	SoftwareId int        `json:"softwareId"`
+	Username   string     `json:"username"`
+
+	Software Software `json:"software"`
+}

--- a/vendor/github.com/TheWeatherCompany/softlayer-go/data_types/softlayer_user_customer.go
+++ b/vendor/github.com/TheWeatherCompany/softlayer-go/data_types/softlayer_user_customer.go
@@ -1,0 +1,42 @@
+package data_types
+
+type SoftLayer_User_Customer_Parameters struct {
+	Parameters []interface{} `json:"parameters"`
+}
+
+type SoftLayer_User_Customer struct {
+	Address1    string `json:"address1,omitempty"`
+	Address2    string `json:"address2,omitempty"`
+	ApiAuthenticationKeys []SoftLayer_User_Customer_ApiAuthentication `json:"apiAuthenticationKeys,omitempty"`
+	City        string `json:"city,omitempty"`
+	CompanyName string `json:"companyName,omitempty"`
+	Country     string `json:"country,omitempty"`
+	DisplayName string `json:"displayName,omitempty"`
+	Email       string `json:"email,omitempty"`
+	FirstName   string `json:"firstName,omitempty"`
+	Id          int    `json:"id,omitempty"`
+	LastName    string `json:"lastName,omitempty"`
+	ParentId    int    `json:"parentId,omitempty"`
+	Permissions []SoftLayer_User_Customer_CustomerPermission_Permission `json:"permissions"`
+	State       string `json:"state,omitempty"`
+	Timezone    int    `json:"timezoneId,omitempty"`
+	UserStatus  int    `json:"userStatusId,omitempty"`
+	Username    string `json:"username,omitempty"`
+}
+
+type SoftLayer_User_Customer_ApiAuthentication struct {
+	Id                int    `json:"id"`
+	AuthenticationKey string `json:"authenticationKey"`
+	UserId            int    `json:"userId"`
+}
+
+type SoftLayer_User_Customer_CustomerPermission_Permission struct {
+	Key               string `json:"key,omitempty"`
+	KeyName           string `json:"keyName"`
+	Name              string `json:"name,omitempty"`
+}
+
+// Deleting a user is actually setting the user status to cancel_pending (1021)
+type SoftLayer_User_Customer_Delete struct {
+	UserStatus int `json:"userStatusId"`
+}

--- a/vendor/github.com/TheWeatherCompany/softlayer-go/data_types/softlayer_virtual_disk_image.go
+++ b/vendor/github.com/TheWeatherCompany/softlayer-go/data_types/softlayer_virtual_disk_image.go
@@ -1,0 +1,20 @@
+package data_types
+
+import (
+	"time"
+)
+
+type SoftLayer_Virtual_Disk_Image struct {
+	Capacity            int        `json:"capacity"`
+	Checksum            string     `json:"checksum"`
+	CreateDate          *time.Time `json:"createDate"`
+	Description         string     `json:"description"`
+	Id                  int        `json:"id"`
+	ModifyDate          *time.Time `json:"modifyDate"`
+	Name                string     `json:"name"`
+	ParentId            int        `json:"parentId"`
+	StorageRepositoryId int        `json:"storageRepositoryId"`
+	TypeId              int        `json:"typeId"`
+	Units               string     `json:"units"`
+	Uuid                string     `json:"uuid"`
+}

--- a/vendor/github.com/TheWeatherCompany/softlayer-go/data_types/softlayer_virtual_guest.go
+++ b/vendor/github.com/TheWeatherCompany/softlayer-go/data_types/softlayer_virtual_guest.go
@@ -1,0 +1,150 @@
+package data_types
+
+import (
+	"time"
+)
+
+type SoftLayer_Virtual_Guest_Parameters struct {
+	Parameters []SoftLayer_Virtual_Guest `json:"parameters"`
+}
+
+type SoftLayer_Virtual_Guest struct {
+	AccountId                    int        `json:"accountId,omitempty"`
+	CreateDate                   *time.Time `json:"createDate,omitempty"`
+	DedicatedAccountHostOnlyFlag bool       `json:"dedicatedAccountHostOnlyFlag,omitempty"`
+	Domain                       string     `json:"domain,omitempty"`
+	FullyQualifiedDomainName     string     `json:"fullyQualifiedDomainName,omitempty"`
+	Hostname                     string     `json:"hostname,omitempty"`
+	Id                           int        `json:"id,omitempty"`
+	LastPowerStateId             int        `json:"lastPowerStateId,omitempty"`
+	LastVerifiedDate             *time.Time `json:"lastVerifiedDate,omitempty"`
+	MaxCpu                       int        `json:"maxCpu,omitempty"`
+	MaxCpuUnits                  string     `json:"maxCpuUnits,omitempty"`
+	MaxMemory                    int        `json:"maxMemory,omitempty"`
+	MetricPollDate               *time.Time `json:"metricPollDate,omitempty"`
+	ModifyDate                   *time.Time `json:"modifyDate,omitempty"`
+	Notes                        string     `json:"notes,omitempty"`
+	PostInstallScriptUri         string     `json:"postInstallScriptUri,omitempty"`
+	PrivateNetworkOnlyFlag       bool       `json:"privateNetworkOnlyFlag,omitempty"`
+	StartCpus                    int        `json:"startCpus,omitempty"`
+	StatusId                     int        `json:"statusId,omitempty"`
+	Uuid                         string     `json:"uuid,omitempty"`
+	LocalDiskFlag                bool       `json:"localDiskFlag,omitempty"`
+	HourlyBillingFlag            bool       `json:"hourlyBillingFlag,omitempty"`
+
+	GlobalIdentifier        string `json:"globalIdentifier,omitempty"`
+	ManagedResourceFlag     bool   `json:"managedResourceFlag,omitempty"`
+	PrimaryBackendIpAddress string `json:"primaryBackendIpAddress,omitempty"`
+	PrimaryIpAddress        string `json:"primaryIpAddress,omitempty"`
+
+	PrimaryNetworkComponent        *PrimaryNetworkComponent        `json:"primaryNetworkComponent,omitempty"`
+	PrimaryBackendNetworkComponent *PrimaryBackendNetworkComponent `json:"primaryBackendNetworkComponent,omitempty"`
+
+	Location          *SoftLayer_Location `json:"location"`
+	Datacenter        *SoftLayer_Location `json:"datacenter"`
+	NetworkComponents []NetworkComponents `json:"networkComponents,omitempty"`
+	UserData          []UserData          `json:"userData,omitempty"`
+
+	OperatingSystem *SoftLayer_Operating_System `json:"operatingSystem"`
+
+	BlockDeviceTemplateGroup *BlockDeviceTemplateGroup `json:"blockDeviceTemplateGroup,omitempty"`
+}
+
+type SoftLayer_Operating_System struct {
+	Passwords []SoftLayer_Password `json:"passwords"`
+}
+
+type SoftLayer_Password struct {
+	Username string `json:"username"`
+	Password string `json:"password"`
+}
+
+type SoftLayer_Virtual_Guest_Template_Parameters struct {
+	Parameters []SoftLayer_Virtual_Guest_Template `json:"parameters"`
+}
+
+type SoftLayer_Virtual_Guest_Template struct {
+	//Required
+	Hostname          string     `json:"hostname"`
+	Domain            string     `json:"domain"`
+	StartCpus         int        `json:"startCpus"`
+	MaxMemory         int        `json:"maxMemory"`
+	Datacenter        Datacenter `json:"datacenter"`
+	HourlyBillingFlag bool       `json:"hourlyBillingFlag"`
+	LocalDiskFlag     bool       `json:"localDiskFlag"`
+
+	//Conditionally required
+	OperatingSystemReferenceCode string                    `json:"operatingSystemReferenceCode,omitempty"`
+	BlockDeviceTemplateGroup     *BlockDeviceTemplateGroup `json:"blockDeviceTemplateGroup,omitempty"`
+
+	//Optional
+	DedicatedAccountHostOnlyFlag   bool                            `json:"dedicatedAccountHostOnlyFlag,omitempty"`
+	NetworkComponents              []NetworkComponents             `json:"networkComponents,omitempty"`
+	PrivateNetworkOnlyFlag         bool                            `json:"privateNetworkOnlyFlag,omitempty"`
+	PrimaryNetworkComponent        *PrimaryNetworkComponent        `json:"primaryNetworkComponent,omitempty"`
+	PrimaryBackendNetworkComponent *PrimaryBackendNetworkComponent `json:"primaryBackendNetworkComponent,omitempty"`
+	PostInstallScriptUri           string                          `json:"postInstallScriptUri,omitempty"`
+
+	BlockDevices []BlockDevice `json:"blockDevices,omitempty"`
+	UserData     []UserData    `json:"userData,omitempty"`
+	SshKeys      []SshKey      `json:"sshKeys,omitempty"`
+}
+
+type Datacenter struct {
+	//Required
+	Name string `json:"name"`
+}
+
+type BlockDeviceTemplateGroup struct {
+	//Required
+	GlobalIdentifier string `json:"globalIdentifier,omitempty"`
+}
+
+type NetworkComponents struct {
+	//Required, defaults to 10
+	MaxSpeed int `json:"maxSpeed,omitempty"`
+}
+
+type NetworkVlan struct {
+	//Required
+	Id int `json:"id,omitempty"`
+}
+
+type PrimaryNetworkComponent struct {
+	//Required
+	NetworkVlan NetworkVlan `json:"networkVlan,omitempty"`
+}
+
+type PrimaryBackendNetworkComponent struct {
+	//Required
+	NetworkVlan NetworkVlan `json:"networkVlan,omitempty"`
+}
+
+type DiskImage struct {
+	//Required
+	Capacity int `json:"capacity,omitempty"`
+}
+
+type BlockDevice struct {
+	//Required
+	Device    string    `json:"device,omitempty"`
+	DiskImage DiskImage `json:"diskImage,omitempty"`
+}
+
+type UserData struct {
+	//Required
+	Value string `json:"value,omitempty"`
+}
+
+type SshKey struct {
+	//Required
+	Id int `json:"id,omitempty"`
+}
+
+type SoftLayer_Virtual_Guest_SetTags_Parameters struct {
+	Parameters []string `json:"parameters"`
+}
+
+type Image_Template_Config struct {
+	ImageTemplateId string `json:"imageTemplateId"`
+}

--- a/vendor/github.com/TheWeatherCompany/softlayer-go/data_types/softlayer_virtual_guest_block_device.go
+++ b/vendor/github.com/TheWeatherCompany/softlayer-go/data_types/softlayer_virtual_guest_block_device.go
@@ -1,0 +1,18 @@
+package data_types
+
+import "time"
+
+type SoftLayer_Virtual_Guest_Block_Device struct {
+	BootableFlag int        `json:"bootableFlag"`
+	CreateDate   *time.Time `json:"createDate"`
+	Device       string     `json:"device"`
+	DiskImageId  int        `json:"diskImageId"`
+	GuestId      int        `json:"guestId"`
+	HotPlugFlag  int        `json:"hotPlugFlag"`
+	Id           int        `json:"id"`
+	ModifyDate   *time.Time `json:"modifyDate"`
+	MountMode    string     `json:"mountMode"`
+	MountType    string     `json:"mountType"`
+	StatusId     int        `json:"statusId"`
+	Uuid         string     `json:"uuid"`
+}

--- a/vendor/github.com/TheWeatherCompany/softlayer-go/data_types/softlayer_virtual_guest_block_device_template_group.go
+++ b/vendor/github.com/TheWeatherCompany/softlayer-go/data_types/softlayer_virtual_guest_block_device_template_group.go
@@ -1,0 +1,18 @@
+package data_types
+
+import "time"
+
+type SoftLayer_Virtual_Guest_Block_Device_Template_Group struct {
+	AccountId        int        `json:"accountId"`
+	CreateDate       *time.Time `json:"createDate"`
+	Id               int        `json:"id"`
+	Name             string     `json:"name"`
+	Note             string     `json:"note"`
+	ParentId         *int       `json:"parentId"`
+	PublicFlag       int        `json:"publicFlag"`
+	StatusId         int        `json:"statusId"`
+	Summary          string     `json:"summary"`
+	TransactionId    *int       `json:"transactionId"`
+	UserRecordId     int        `json:"userRecordId"`
+	GlobalIdentifier string     `json:"globalIdentifier"`
+}

--- a/vendor/github.com/TheWeatherCompany/softlayer-go/data_types/softlayer_virtual_guest_init_parameters.go
+++ b/vendor/github.com/TheWeatherCompany/softlayer-go/data_types/softlayer_virtual_guest_init_parameters.go
@@ -1,0 +1,13 @@
+package data_types
+
+type SoftLayer_Virtual_GuestInitParameters struct {
+	Parameters []interface{} `json:"parameters"`
+}
+
+type SoftLayer_Virtual_GuestInit_ImageId_Parameters struct {
+	Parameters ImageId_Parameter `json:"parameters"`
+}
+
+type ImageId_Parameter struct {
+	ImageId int `json:"imageId"`
+}

--- a/vendor/github.com/TheWeatherCompany/softlayer-go/data_types/softlayer_virtual_guest_power_state.go
+++ b/vendor/github.com/TheWeatherCompany/softlayer-go/data_types/softlayer_virtual_guest_power_state.go
@@ -1,0 +1,7 @@
+package data_types
+
+type SoftLayer_Virtual_Guest_Power_State struct {
+	Description string `json:"description"`
+	KeyName     string `json:"keyName"`
+	Name        string `json:"name"`
+}

--- a/vendor/github.com/TheWeatherCompany/softlayer-go/services/softLayer_account.go
+++ b/vendor/github.com/TheWeatherCompany/softlayer-go/services/softLayer_account.go
@@ -1,0 +1,494 @@
+package services
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/TheWeatherCompany/softlayer-go/common"
+	datatypes "github.com/TheWeatherCompany/softlayer-go/data_types"
+	softlayer "github.com/TheWeatherCompany/softlayer-go/softlayer"
+)
+
+type softLayer_Account_Service struct {
+	client softlayer.Client
+}
+
+func NewSoftLayer_Account_Service(client softlayer.Client) *softLayer_Account_Service {
+	return &softLayer_Account_Service{
+		client: client,
+	}
+}
+
+func (slas *softLayer_Account_Service) GetName() string {
+	return "SoftLayer_Account"
+}
+
+func (slas *softLayer_Account_Service) GetAccountStatus() (datatypes.SoftLayer_Account_Status, error) {
+	path := fmt.Sprintf("%s/%s", slas.GetName(), "getAccountStatus.json")
+	responseBytes, errorCode, err := slas.client.GetHttpClient().DoRawHttpRequest(path, "GET", &bytes.Buffer{})
+	if err != nil {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Account#getAccountStatus, error message '%s'", err.Error())
+		return datatypes.SoftLayer_Account_Status{}, errors.New(errorMessage)
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Account#getAccountStatus, HTTP error code: '%d'", errorCode)
+		return datatypes.SoftLayer_Account_Status{}, errors.New(errorMessage)
+	}
+
+	accountStatus := datatypes.SoftLayer_Account_Status{}
+	err = json.Unmarshal(responseBytes, &accountStatus)
+	if err != nil {
+		errorMessage := fmt.Sprintf("softlayer-go: failed to decode JSON response, err message '%s'", err.Error())
+		err := errors.New(errorMessage)
+		return datatypes.SoftLayer_Account_Status{}, err
+	}
+
+	return accountStatus, nil
+}
+
+func (slas *softLayer_Account_Service) GetUsers() ([]datatypes.SoftLayer_User_Customer, error) {
+	path := fmt.Sprintf("%s/%s", slas.GetName(), "getUsers.json")
+	responseBytes, errorCode, err := slas.client.GetHttpClient().DoRawHttpRequest(path, "GET", &bytes.Buffer{})
+	if err != nil {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Account#getUsers, error message '%s'", err.Error())
+		return nil, errors.New(errorMessage)
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Account#getUsers, HTTP error code: '%d'", errorCode)
+		return nil, errors.New(errorMessage)
+	}
+
+	users := []datatypes.SoftLayer_User_Customer{}
+	if err = json.Unmarshal(responseBytes, &users); err != nil {
+		errorMessage := fmt.Sprintf(
+			"softlayer-go: failed to decode SoftLayer_Account#getUsers JSON response, error message: '%s'",
+			err.Error(),
+		)
+		return nil, errors.New(errorMessage)
+	}
+
+	return users, nil
+}
+
+func (slas *softLayer_Account_Service) GetVirtualGuests() ([]datatypes.SoftLayer_Virtual_Guest, error) {
+	path := fmt.Sprintf("%s/%s", slas.GetName(), "getVirtualGuests.json")
+	responseBytes, errorCode, err := slas.client.GetHttpClient().DoRawHttpRequest(path, "GET", &bytes.Buffer{})
+	if err != nil {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Account#getVirtualGuests, error message '%s'", err.Error())
+		return []datatypes.SoftLayer_Virtual_Guest{}, errors.New(errorMessage)
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Account#getVirtualGuests, HTTP error code: '%d'", errorCode)
+		return []datatypes.SoftLayer_Virtual_Guest{}, errors.New(errorMessage)
+	}
+
+	virtualGuests := []datatypes.SoftLayer_Virtual_Guest{}
+	err = json.Unmarshal(responseBytes, &virtualGuests)
+	if err != nil {
+		errorMessage := fmt.Sprintf("softlayer-go: failed to decode JSON response, err message '%s'", err.Error())
+		err := errors.New(errorMessage)
+		return []datatypes.SoftLayer_Virtual_Guest{}, err
+	}
+
+	return virtualGuests, nil
+}
+
+func (slas *softLayer_Account_Service) GetVirtualGuestsByFilter(filters string) ([]datatypes.SoftLayer_Virtual_Guest, error) {
+	path := fmt.Sprintf("%s/%s", slas.GetName(), "getVirtualGuests.json")
+
+	objectMasks := []string{
+		"accountId",
+		"createDate",
+		"dedicatedAccountHostOnlyFlag",
+		"domain",
+		"fullyQualifiedDomainName",
+		"hostname",
+		"hourlyBillingFlag",
+		"id",
+		"lastPowerStateId",
+		"lastVerifiedDate",
+		"maxCpu",
+		"maxCpuUnits",
+		"maxMemory",
+		"metricPollDate",
+		"modifyDate",
+		"notes",
+		"postInstallScriptUri",
+		"privateNetworkOnlyFlag",
+		"startCpus",
+		"statusId",
+		"uuid",
+		"userData.value",
+		"localDiskFlag",
+
+		"globalIdentifier",
+		"managedResourceFlag",
+		"primaryBackendIpAddress",
+		"primaryIpAddress",
+
+		"location.name",
+		"location.longName",
+		"location.id",
+		"datacenter.name",
+		"datacenter.longName",
+		"datacenter.id",
+		"networkComponents.maxSpeed",
+		"operatingSystem.passwords.password",
+		"operatingSystem.passwords.username",
+
+		"blockDeviceTemplateGroup.globalIdentifier",
+		"primaryNetworkComponent.networkVlan.id",
+		"primaryBackendNetworkComponent.networkVlan.id",
+	}
+
+	responseBytes, errorCode, err := slas.client.GetHttpClient().DoRawHttpRequestWithObjectFilterAndObjectMask(path, objectMasks, filters, "GET", &bytes.Buffer{})
+	if err != nil {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Account#getVirtualGuests, error message '%s'", err.Error())
+		return []datatypes.SoftLayer_Virtual_Guest{}, errors.New(errorMessage)
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Account#getVirtualGuests, HTTP error code: '%d'", errorCode)
+		return []datatypes.SoftLayer_Virtual_Guest{}, errors.New(errorMessage)
+	}
+
+	virtualGuests := []datatypes.SoftLayer_Virtual_Guest{}
+	err = json.Unmarshal(responseBytes, &virtualGuests)
+	if err != nil {
+		errorMessage := fmt.Sprintf("softlayer-go: failed to decode JSON response, err message '%s'", err.Error())
+		err := errors.New(errorMessage)
+		return []datatypes.SoftLayer_Virtual_Guest{}, err
+	}
+
+	return virtualGuests, nil
+}
+
+func (slas *softLayer_Account_Service) GetNetworkStorage() ([]datatypes.SoftLayer_Network_Storage, error) {
+	path := fmt.Sprintf("%s/%s", slas.GetName(), "getNetworkStorage.json")
+	responseBytes, errorCode, err := slas.client.GetHttpClient().DoRawHttpRequest(path, "GET", &bytes.Buffer{})
+	if err != nil {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Account#getNetworkStorage, error message '%s'", err.Error())
+		return []datatypes.SoftLayer_Network_Storage{}, errors.New(errorMessage)
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Account#getNetworkStorage, HTTP error code: '%d'", errorCode)
+		return []datatypes.SoftLayer_Network_Storage{}, errors.New(errorMessage)
+	}
+
+	networkStorage := []datatypes.SoftLayer_Network_Storage{}
+	err = json.Unmarshal(responseBytes, &networkStorage)
+	if err != nil {
+		errorMessage := fmt.Sprintf("softlayer-go: failed to decode JSON response, err message '%s'", err.Error())
+		err := errors.New(errorMessage)
+		return []datatypes.SoftLayer_Network_Storage{}, err
+	}
+
+	return networkStorage, nil
+}
+
+func (slas *softLayer_Account_Service) GetHubNetworkStorage() ([]datatypes.SoftLayer_Network_Storage, error) {
+	path := fmt.Sprintf("%s/%s", slas.GetName(), "getHubNetworkStorage.json")
+	responseBytes, errorCode, err := slas.client.GetHttpClient().DoRawHttpRequest(path, "GET", &bytes.Buffer{})
+	if err != nil {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Account#getHubNetworkStorage, error message '%s'", err.Error())
+		return []datatypes.SoftLayer_Network_Storage{}, errors.New(errorMessage)
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Account#getHubNetworkStorage, HTTP error code: '%d'", errorCode)
+		return []datatypes.SoftLayer_Network_Storage{}, errors.New(errorMessage)
+	}
+
+	networkStorage := []datatypes.SoftLayer_Network_Storage{}
+	err = json.Unmarshal(responseBytes, &networkStorage)
+	if err != nil {
+		errorMessage := fmt.Sprintf("softlayer-go: failed to decode JSON response, err message '%s'", err.Error())
+		err := errors.New(errorMessage)
+		return []datatypes.SoftLayer_Network_Storage{}, err
+	}
+
+	return networkStorage, nil
+}
+
+func (slas *softLayer_Account_Service) GetIscsiNetworkStorage() ([]datatypes.SoftLayer_Network_Storage, error) {
+	path := fmt.Sprintf("%s/%s", slas.GetName(), "getIscsiNetworkStorage.json")
+
+	objectMasks := []string{
+		"username",
+		"accountId",
+		"capacityGb",
+		"id",
+		"billingItem.id",
+		"billingItem.orderItem.order.id",
+	}
+
+	responseBytes, errorCode, err := slas.client.GetHttpClient().DoRawHttpRequestWithObjectMask(path, objectMasks, "GET", &bytes.Buffer{})
+	if err != nil {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Account#getIscsiNetworkStorage, error message '%s'", err.Error())
+		return []datatypes.SoftLayer_Network_Storage{}, errors.New(errorMessage)
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Account#getIscsiNetworkStorage, HTTP error code: '%d'", errorCode)
+		return []datatypes.SoftLayer_Network_Storage{}, errors.New(errorMessage)
+	}
+
+	networkStorage := []datatypes.SoftLayer_Network_Storage{}
+	err = json.Unmarshal(responseBytes, &networkStorage)
+	if err != nil {
+		errorMessage := fmt.Sprintf("softlayer-go: failed to decode JSON response, err message '%s'", err.Error())
+		err := errors.New(errorMessage)
+		return []datatypes.SoftLayer_Network_Storage{}, err
+	}
+
+	return networkStorage, nil
+}
+
+func (slas *softLayer_Account_Service) GetIscsiNetworkStorageWithFilter(filter string) ([]datatypes.SoftLayer_Network_Storage, error) {
+	path := fmt.Sprintf("%s/%s", slas.GetName(), "getIscsiNetworkStorage.json")
+
+	objectMasks := []string{
+		"username",
+		"accountId",
+		"capacityGb",
+		"id",
+		"billingItem.id",
+		"billingItem.orderItem.order.id",
+	}
+
+	responseBytes, errorCode, err := slas.client.GetHttpClient().DoRawHttpRequestWithObjectFilterAndObjectMask(path, objectMasks, filter, "GET", &bytes.Buffer{})
+	if err != nil {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Account#getIscsiNetworkStorage, error message '%s'", err.Error())
+		return []datatypes.SoftLayer_Network_Storage{}, errors.New(errorMessage)
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Account#getIscsiNetworkStorage, HTTP error code: '%d'", errorCode)
+		return []datatypes.SoftLayer_Network_Storage{}, errors.New(errorMessage)
+	}
+
+	networkStorage := []datatypes.SoftLayer_Network_Storage{}
+	err = json.Unmarshal(responseBytes, &networkStorage)
+	if err != nil {
+		errorMessage := fmt.Sprintf("softlayer-go: failed to decode JSON response, err message '%s'", err.Error())
+		err := errors.New(errorMessage)
+		return []datatypes.SoftLayer_Network_Storage{}, err
+	}
+
+	return networkStorage, nil
+}
+
+func (slas *softLayer_Account_Service) GetApplicationDeliveryControllersWithFilter(filter string) ([]datatypes.SoftLayer_Network_Application_Delivery_Controller, error) {
+	path := fmt.Sprintf("%s/%s", slas.GetName(), "getApplicationDeliveryControllers.json")
+
+	responseBytes, errorCode, err := slas.client.GetHttpClient().DoRawHttpRequestWithObjectFilter(path, filter, "GET", &bytes.Buffer{})
+	if err != nil {
+		errorMessage := fmt.Sprintf("softlayer-go: could not get SoftLayer_Account#getApplicationDeliveryControllersWithFilter, error message '%s'", err.Error())
+		return []datatypes.SoftLayer_Network_Application_Delivery_Controller{}, errors.New(errorMessage)
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not get SoftLayer_Account#getApplicationDeliveryControllersWithFilter, HTTP error code: '%d'", errorCode)
+		return []datatypes.SoftLayer_Network_Application_Delivery_Controller{}, errors.New(errorMessage)
+	}
+
+	nadc := []datatypes.SoftLayer_Network_Application_Delivery_Controller{}
+	err = json.Unmarshal(responseBytes, &nadc)
+	if err != nil {
+		return []datatypes.SoftLayer_Network_Application_Delivery_Controller{}, fmt.Errorf("softlayer-go: failed to decode JSON response, err message '%s'", err.Error())
+	}
+
+	return nadc, nil
+}
+
+func (slas *softLayer_Account_Service) GetVirtualDiskImages() ([]datatypes.SoftLayer_Virtual_Disk_Image, error) {
+	path := fmt.Sprintf("%s/%s", slas.GetName(), "getVirtualDiskImages.json")
+	responseBytes, errorCode, err := slas.client.GetHttpClient().DoRawHttpRequest(path, "GET", &bytes.Buffer{})
+	if err != nil {
+		errorMessage := fmt.Sprintf("softlayer-go: could not get SoftLayer_Account#getVirtualDiskImages, error message '%s'", err.Error())
+		return []datatypes.SoftLayer_Virtual_Disk_Image{}, errors.New(errorMessage)
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not get SoftLayer_Account#getVirtualDiskImages, HTTP error code: '%d'", errorCode)
+		return []datatypes.SoftLayer_Virtual_Disk_Image{}, errors.New(errorMessage)
+	}
+
+	virtualDiskImages := []datatypes.SoftLayer_Virtual_Disk_Image{}
+	err = json.Unmarshal(responseBytes, &virtualDiskImages)
+	if err != nil {
+		errorMessage := fmt.Sprintf("softlayer-go: failed to decode JSON response, err message '%s'", err.Error())
+		err := errors.New(errorMessage)
+		return []datatypes.SoftLayer_Virtual_Disk_Image{}, err
+	}
+
+	return virtualDiskImages, nil
+}
+
+func (slas *softLayer_Account_Service) GetVirtualDiskImagesWithFilter(filters string) ([]datatypes.SoftLayer_Virtual_Disk_Image, error) {
+	isJson, err := common.ValidateJson(filters)
+	if !isJson || err != nil {
+		errorMessage := fmt.Sprintf("softlayer-go: filters string %s is not a valid Json formatted string, error message '%s'", filters, err.Error())
+		return []datatypes.SoftLayer_Virtual_Disk_Image{}, errors.New(errorMessage)
+	}
+
+	path := fmt.Sprintf("%s/%s", slas.GetName(), "getVirtualDiskImages.json")
+	responseBytes, errorCode, err := slas.client.GetHttpClient().DoRawHttpRequestWithObjectFilter(path, filters, "GET", &bytes.Buffer{})
+	if err != nil {
+		errorMessage := fmt.Sprintf("softlayer-go: could not get SoftLayer_Account#getVirtualDiskImages, error message '%s'", err.Error())
+		return []datatypes.SoftLayer_Virtual_Disk_Image{}, errors.New(errorMessage)
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not get SoftLayer_Account#getVirtualDiskImages, HTTP error code: '%d'", errorCode)
+		return []datatypes.SoftLayer_Virtual_Disk_Image{}, errors.New(errorMessage)
+	}
+
+	virtualDiskImages := []datatypes.SoftLayer_Virtual_Disk_Image{}
+	err = json.Unmarshal(responseBytes, &virtualDiskImages)
+	if err != nil {
+		errorMessage := fmt.Sprintf("softlayer-go: failed to decode JSON response, err message '%s'", err.Error())
+		err := errors.New(errorMessage)
+		return []datatypes.SoftLayer_Virtual_Disk_Image{}, err
+	}
+
+	return virtualDiskImages, nil
+}
+
+func (slas *softLayer_Account_Service) GetSshKeys() ([]datatypes.SoftLayer_Security_Ssh_Key, error) {
+	path := fmt.Sprintf("%s/%s", slas.GetName(), "getSshKeys.json")
+	responseBytes, errorCode, err := slas.client.GetHttpClient().DoRawHttpRequest(path, "GET", &bytes.Buffer{})
+	if err != nil {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Account#getSshKeys, error message '%s'", err.Error())
+		return []datatypes.SoftLayer_Security_Ssh_Key{}, errors.New(errorMessage)
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Account#getSshKeys, HTTP error code: '%d'", errorCode)
+		return []datatypes.SoftLayer_Security_Ssh_Key{}, errors.New(errorMessage)
+	}
+
+	sshKeys := []datatypes.SoftLayer_Security_Ssh_Key{}
+	err = json.Unmarshal(responseBytes, &sshKeys)
+	if err != nil {
+		errorMessage := fmt.Sprintf("softlayer-go: failed to decode JSON response, err message '%s'", err.Error())
+		err := errors.New(errorMessage)
+		return []datatypes.SoftLayer_Security_Ssh_Key{}, err
+	}
+
+	return sshKeys, nil
+}
+
+func (slas *softLayer_Account_Service) GetBlockDeviceTemplateGroups() ([]datatypes.SoftLayer_Virtual_Guest_Block_Device_Template_Group, error) {
+	path := fmt.Sprintf("%s/%s", slas.GetName(), "getBlockDeviceTemplateGroups.json")
+	responseBytes, errorCode, err := slas.client.GetHttpClient().DoRawHttpRequest(path, "GET", &bytes.Buffer{})
+	if err != nil {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Account#getBlockDeviceTemplateGroups, error message '%s'", err.Error())
+		return []datatypes.SoftLayer_Virtual_Guest_Block_Device_Template_Group{}, errors.New(errorMessage)
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Account#getBlockDeviceTemplateGroups, HTTP error code: '%d'", errorCode)
+		return []datatypes.SoftLayer_Virtual_Guest_Block_Device_Template_Group{}, errors.New(errorMessage)
+	}
+
+	vgbdtGroups := []datatypes.SoftLayer_Virtual_Guest_Block_Device_Template_Group{}
+	err = json.Unmarshal(responseBytes, &vgbdtGroups)
+	if err != nil {
+		errorMessage := fmt.Sprintf("softlayer-go: failed to decode JSON response, err message '%s'", err.Error())
+		err := errors.New(errorMessage)
+		return []datatypes.SoftLayer_Virtual_Guest_Block_Device_Template_Group{}, err
+	}
+
+	return vgbdtGroups, nil
+}
+
+func (slas *softLayer_Account_Service) GetBlockDeviceTemplateGroupsWithFilter(filters string) ([]datatypes.SoftLayer_Virtual_Guest_Block_Device_Template_Group, error) {
+	isJson, err := common.ValidateJson(filters)
+	if !isJson || err != nil {
+		errorMessage := fmt.Sprintf("softlayer-go: filters string %s is not a valid Json formatted string, error message '%s'", filters, err.Error())
+		return []datatypes.SoftLayer_Virtual_Guest_Block_Device_Template_Group{}, errors.New(errorMessage)
+	}
+
+	path := fmt.Sprintf("%s/%s", slas.GetName(), "getBlockDeviceTemplateGroups.json")
+	responseBytes, errorCode, err := slas.client.GetHttpClient().DoRawHttpRequestWithObjectFilter(path, filters, "GET", &bytes.Buffer{})
+	if err != nil {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Account#getBlockDeviceTemplateGroups, error message '%s'", err.Error())
+		return []datatypes.SoftLayer_Virtual_Guest_Block_Device_Template_Group{}, errors.New(errorMessage)
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Account#getBlockDeviceTemplateGroups, HTTP error code: '%d'", errorCode)
+		return []datatypes.SoftLayer_Virtual_Guest_Block_Device_Template_Group{}, errors.New(errorMessage)
+	}
+
+	vgbdtGroups := []datatypes.SoftLayer_Virtual_Guest_Block_Device_Template_Group{}
+	err = json.Unmarshal(responseBytes, &vgbdtGroups)
+	if err != nil {
+		errorMessage := fmt.Sprintf("softlayer-go: failed to decode JSON response, err message '%s'", err.Error())
+		err := errors.New(errorMessage)
+		return []datatypes.SoftLayer_Virtual_Guest_Block_Device_Template_Group{}, err
+	}
+
+	return vgbdtGroups, nil
+}
+
+//TODO: why is this method empty? Remove?
+func (slas *softLayer_Account_Service) GetDatacentersWithSubnetAllocations() ([]datatypes.SoftLayer_Location, error) {
+	return []datatypes.SoftLayer_Location{}, nil
+}
+
+func (slas *softLayer_Account_Service) GetHardware() ([]datatypes.SoftLayer_Hardware, error) {
+	path := fmt.Sprintf("%s/%s", slas.GetName(), "getHardware.json")
+	responseBytes, errorCode, err := slas.client.GetHttpClient().DoRawHttpRequest(path, "GET", &bytes.Buffer{})
+	if err != nil {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Account#getHardware, error message '%s'", err.Error())
+		return []datatypes.SoftLayer_Hardware{}, errors.New(errorMessage)
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Account#getHardware, HTTP error code: '%d'", errorCode)
+		return []datatypes.SoftLayer_Hardware{}, errors.New(errorMessage)
+	}
+
+	hardwares := []datatypes.SoftLayer_Hardware{}
+	err = json.Unmarshal(responseBytes, &hardwares)
+
+	if err != nil {
+		errorMessage := fmt.Sprintf("softlayer-go: failed to decode JSON response, err message '%s'", err.Error())
+		err := errors.New(errorMessage)
+		return []datatypes.SoftLayer_Hardware{}, err
+	}
+
+	return hardwares, nil
+}
+
+func (slas *softLayer_Account_Service) GetDnsDomains() ([]datatypes.SoftLayer_Dns_Domain, error) {
+	path := fmt.Sprintf("%s/%s", slas.GetName(), "getDomains.json")
+	responseBytes, errorCode, err := slas.client.GetHttpClient().DoRawHttpRequest(path, "GET", &bytes.Buffer{})
+	if err != nil {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Account#getDomains, error message '%s'", err.Error())
+		return []datatypes.SoftLayer_Dns_Domain{}, errors.New(errorMessage)
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Account#getDomains, HTTP error code: '%d'", errorCode)
+		return []datatypes.SoftLayer_Dns_Domain{}, errors.New(errorMessage)
+	}
+
+	domains := []datatypes.SoftLayer_Dns_Domain{}
+	err = json.Unmarshal(responseBytes, &domains)
+	if err != nil {
+		errorMessage := fmt.Sprintf("softlayer-go: failed to decode JSON response, err message '%s'", err.Error())
+		err := errors.New(errorMessage)
+		return []datatypes.SoftLayer_Dns_Domain{}, err
+	}
+
+	return domains, nil
+}

--- a/vendor/github.com/TheWeatherCompany/softlayer-go/services/softLayer_virtual_guest_block_device_template_group.go
+++ b/vendor/github.com/TheWeatherCompany/softlayer-go/services/softLayer_virtual_guest_block_device_template_group.go
@@ -1,0 +1,444 @@
+package services
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+
+	common "github.com/TheWeatherCompany/softlayer-go/common"
+	datatypes "github.com/TheWeatherCompany/softlayer-go/data_types"
+	softlayer "github.com/TheWeatherCompany/softlayer-go/softlayer"
+)
+
+type softLayer_Virtual_Guest_Block_Device_Template_Group_Service struct {
+	client softlayer.Client
+}
+
+func NewSoftLayer_Virtual_Guest_Block_Device_Template_Group_Service(client softlayer.Client) *softLayer_Virtual_Guest_Block_Device_Template_Group_Service {
+	return &softLayer_Virtual_Guest_Block_Device_Template_Group_Service{
+		client: client,
+	}
+}
+
+func (slvgs *softLayer_Virtual_Guest_Block_Device_Template_Group_Service) GetName() string {
+	return "SoftLayer_Virtual_Guest_Block_Device_Template_Group"
+}
+
+func (slvgbdtg *softLayer_Virtual_Guest_Block_Device_Template_Group_Service) GetObject(id int) (datatypes.SoftLayer_Virtual_Guest_Block_Device_Template_Group, error) {
+	response, errorCode, err := slvgbdtg.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/getObject.json", slvgbdtg.GetName(), id), "GET", new(bytes.Buffer))
+	if err != nil {
+		return datatypes.SoftLayer_Virtual_Guest_Block_Device_Template_Group{}, err
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Virtual_Guest_Block_Device_Template_Group#getObject, HTTP error code: '%d'", errorCode)
+		return datatypes.SoftLayer_Virtual_Guest_Block_Device_Template_Group{}, errors.New(errorMessage)
+	}
+
+	vgbdtGroup := datatypes.SoftLayer_Virtual_Guest_Block_Device_Template_Group{}
+	err = json.Unmarshal(response, &vgbdtGroup)
+	if err != nil {
+		return datatypes.SoftLayer_Virtual_Guest_Block_Device_Template_Group{}, err
+	}
+
+	return vgbdtGroup, nil
+}
+
+func (slvgbdtg *softLayer_Virtual_Guest_Block_Device_Template_Group_Service) DeleteObject(id int) (datatypes.SoftLayer_Provisioning_Version1_Transaction, error) {
+	response, errorCode, err := slvgbdtg.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d.json", slvgbdtg.GetName(), id), "DELETE", new(bytes.Buffer))
+	if err != nil {
+		return datatypes.SoftLayer_Provisioning_Version1_Transaction{}, err
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Virtual_Guest_Block_Device_Template_Group#deleteObject, HTTP error code: '%d'", errorCode)
+		return datatypes.SoftLayer_Provisioning_Version1_Transaction{}, errors.New(errorMessage)
+	}
+
+	transaction := datatypes.SoftLayer_Provisioning_Version1_Transaction{}
+	err = json.Unmarshal(response, &transaction)
+	if err != nil {
+		return datatypes.SoftLayer_Provisioning_Version1_Transaction{}, err
+	}
+
+	return transaction, nil
+}
+
+func (slvgbdtg *softLayer_Virtual_Guest_Block_Device_Template_Group_Service) GetDatacenters(id int) ([]datatypes.SoftLayer_Location, error) {
+	response, errorCode, err := slvgbdtg.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/getDatacenters.json", slvgbdtg.GetName(), id), "GET", new(bytes.Buffer))
+	if err != nil {
+		return []datatypes.SoftLayer_Location{}, err
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Virtual_Guest_Block_Device_Template_Group#getDatacenters, HTTP error code: '%d'", errorCode)
+		return []datatypes.SoftLayer_Location{}, errors.New(errorMessage)
+	}
+
+	locations := []datatypes.SoftLayer_Location{}
+	err = json.Unmarshal(response, &locations)
+	if err != nil {
+		return []datatypes.SoftLayer_Location{}, err
+	}
+
+	return locations, nil
+}
+
+func (slvgbdtg *softLayer_Virtual_Guest_Block_Device_Template_Group_Service) GetSshKeys(id int) ([]datatypes.SoftLayer_Security_Ssh_Key, error) {
+	response, errorCode, err := slvgbdtg.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/getSshKeys.json", slvgbdtg.GetName(), id), "GET", new(bytes.Buffer))
+	if err != nil {
+		return []datatypes.SoftLayer_Security_Ssh_Key{}, err
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Virtual_Guest_Block_Device_Template_Group#getSshKeys, HTTP error code: '%d'", errorCode)
+		return []datatypes.SoftLayer_Security_Ssh_Key{}, errors.New(errorMessage)
+	}
+
+	sshKeys := []datatypes.SoftLayer_Security_Ssh_Key{}
+	err = json.Unmarshal(response, &sshKeys)
+	if err != nil {
+		return []datatypes.SoftLayer_Security_Ssh_Key{}, err
+	}
+
+	return sshKeys, nil
+}
+
+func (slvgbdtg *softLayer_Virtual_Guest_Block_Device_Template_Group_Service) GetStatus(id int) (datatypes.SoftLayer_Virtual_Guest_Block_Device_Template_Group_Status, error) {
+	response, errorCode, err := slvgbdtg.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/getStatus.json", slvgbdtg.GetName(), id), "GET", new(bytes.Buffer))
+	if err != nil {
+		return datatypes.SoftLayer_Virtual_Guest_Block_Device_Template_Group_Status{}, err
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Virtual_Guest_Block_Device_Template_Group#getStatus, HTTP error code: '%d'", errorCode)
+		return datatypes.SoftLayer_Virtual_Guest_Block_Device_Template_Group_Status{}, errors.New(errorMessage)
+	}
+
+	status := datatypes.SoftLayer_Virtual_Guest_Block_Device_Template_Group_Status{}
+	err = json.Unmarshal(response, &status)
+	if err != nil {
+		return datatypes.SoftLayer_Virtual_Guest_Block_Device_Template_Group_Status{}, err
+	}
+
+	return status, nil
+}
+
+func (slvgbdtg *softLayer_Virtual_Guest_Block_Device_Template_Group_Service) GetImageType(id int) (datatypes.SoftLayer_Image_Type, error) {
+	response, errorCode, err := slvgbdtg.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/getImageType.json", slvgbdtg.GetName(), id), "GET", new(bytes.Buffer))
+	if err != nil {
+		return datatypes.SoftLayer_Image_Type{}, err
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Virtual_Guest_Block_Device_Template_Group#getImageType, HTTP error code: '%d'", errorCode)
+		return datatypes.SoftLayer_Image_Type{}, errors.New(errorMessage)
+	}
+
+	imageType := datatypes.SoftLayer_Image_Type{}
+	err = json.Unmarshal(response, &imageType)
+	if err != nil {
+		return datatypes.SoftLayer_Image_Type{}, err
+	}
+
+	return imageType, nil
+}
+
+func (slvgbdtg *softLayer_Virtual_Guest_Block_Device_Template_Group_Service) GetStorageLocations(id int) ([]datatypes.SoftLayer_Location, error) {
+	response, errorCode, err := slvgbdtg.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/getStorageLocations.json", slvgbdtg.GetName(), id), "GET", new(bytes.Buffer))
+	if err != nil {
+		return []datatypes.SoftLayer_Location{}, err
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Virtual_Guest_Block_Device_Template_Group#getStorageLocations, HTTP error code: '%d'", errorCode)
+		return []datatypes.SoftLayer_Location{}, errors.New(errorMessage)
+	}
+
+	locations := []datatypes.SoftLayer_Location{}
+	err = json.Unmarshal(response, &locations)
+	if err != nil {
+		return []datatypes.SoftLayer_Location{}, err
+	}
+
+	return locations, nil
+}
+
+func (slvgbdtg *softLayer_Virtual_Guest_Block_Device_Template_Group_Service) CreateFromExternalSource(configuration datatypes.SoftLayer_Container_Virtual_Guest_Block_Device_Template_Configuration) (datatypes.SoftLayer_Virtual_Guest_Block_Device_Template_Group, error) {
+	parameters := datatypes.SoftLayer_Container_Virtual_Guest_Block_Device_Template_Configuration_Parameters{
+		Parameters: []datatypes.SoftLayer_Container_Virtual_Guest_Block_Device_Template_Configuration{configuration},
+	}
+
+	requestBody, err := json.Marshal(parameters)
+	if err != nil {
+		return datatypes.SoftLayer_Virtual_Guest_Block_Device_Template_Group{}, err
+	}
+
+	response, errorCode, err := slvgbdtg.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/createFromExternalSource.json", slvgbdtg.GetName()), "POST", bytes.NewBuffer(requestBody))
+	if err != nil {
+		return datatypes.SoftLayer_Virtual_Guest_Block_Device_Template_Group{}, err
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Virtual_Guest_Block_Device_Template_Group#createFromExternalSource, HTTP error code: '%d'", errorCode)
+		return datatypes.SoftLayer_Virtual_Guest_Block_Device_Template_Group{}, errors.New(errorMessage)
+	}
+
+	vgbdtGroup := datatypes.SoftLayer_Virtual_Guest_Block_Device_Template_Group{}
+	err = json.Unmarshal(response, &vgbdtGroup)
+	if err != nil {
+		return datatypes.SoftLayer_Virtual_Guest_Block_Device_Template_Group{}, err
+	}
+
+	return vgbdtGroup, err
+}
+
+func (slvgbdtg *softLayer_Virtual_Guest_Block_Device_Template_Group_Service) CopyToExternalSource(configuration datatypes.SoftLayer_Container_Virtual_Guest_Block_Device_Template_Configuration) (bool, error) {
+	parameters := datatypes.SoftLayer_Container_Virtual_Guest_Block_Device_Template_Configuration_Parameters{
+		Parameters: []datatypes.SoftLayer_Container_Virtual_Guest_Block_Device_Template_Configuration{configuration},
+	}
+
+	requestBody, err := json.Marshal(parameters)
+	if err != nil {
+		return false, err
+	}
+
+	response, errorCode, err := slvgbdtg.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/copyToExternalSource.json", slvgbdtg.GetName()), "POST", bytes.NewBuffer(requestBody))
+	if err != nil {
+		return false, err
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Virtual_Guest_Block_Device_Template_Group#copyToExternalSource, HTTP error code: '%d'", errorCode)
+		return false, errors.New(errorMessage)
+	}
+
+	if res := string(response[:]); res != "true" {
+		return false, errors.New(fmt.Sprintf("Failed to create virtual guest block device template group, got '%s' as response from the API.", res))
+	}
+
+	return true, nil
+}
+
+func (slvgbdtg *softLayer_Virtual_Guest_Block_Device_Template_Group_Service) GetImageTypeKeyName(id int) (string, error) {
+	response, errorCode, err := slvgbdtg.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/getImageTypeKeyName.json", slvgbdtg.GetName(), id), "GET", new(bytes.Buffer))
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Virtual_Guest_Block_Device_Template_Group#getImageTypeKeyName, HTTP error code: '%d'", errorCode)
+		return "", errors.New(errorMessage)
+	}
+
+	return string(response), err
+}
+
+func (slvgbdtg *softLayer_Virtual_Guest_Block_Device_Template_Group_Service) GetTransaction(id int) (datatypes.SoftLayer_Provisioning_Version1_Transaction, error) {
+	response, errorCode, err := slvgbdtg.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/getTransaction.json", slvgbdtg.GetName(), id), "GET", new(bytes.Buffer))
+	if err != nil {
+		return datatypes.SoftLayer_Provisioning_Version1_Transaction{}, err
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Virtual_Guest_Block_Device_Template_Group#getTransaction, HTTP error code: '%d'", errorCode)
+		return datatypes.SoftLayer_Provisioning_Version1_Transaction{}, errors.New(errorMessage)
+	}
+
+	transaction := datatypes.SoftLayer_Provisioning_Version1_Transaction{}
+	err = json.Unmarshal(response, &transaction)
+	if err != nil {
+		return datatypes.SoftLayer_Provisioning_Version1_Transaction{}, err
+	}
+
+	return transaction, nil
+}
+
+func (slvgbdtg *softLayer_Virtual_Guest_Block_Device_Template_Group_Service) DenySharingAccess(id int, accountId int) (bool, error) {
+	parameters := datatypes.SoftLayer_Virtual_Guest_Block_Device_Template_GroupInitParameters{
+		Parameters: datatypes.SoftLayer_Virtual_Guest_Block_Device_Template_GroupInitParameter{
+			AccountId: accountId,
+		},
+	}
+
+	requestBody, err := json.Marshal(parameters)
+	if err != nil {
+		return false, err
+	}
+
+	response, errorCode, err := slvgbdtg.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/denySharingAccess.json", slvgbdtg.GetName(), id), "POST", bytes.NewBuffer(requestBody))
+	if err != nil {
+		return false, err
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Virtual_Guest_Block_Device_Template_Group#denySharingAccess, HTTP error code: '%d'", errorCode)
+		return false, errors.New(errorMessage)
+	}
+
+	if res := string(response[:]); res != "true" {
+		return false, errors.New(fmt.Sprintf("Failed to permit sharing access to VGDBTG with ID: %d to account ID: %d", id, accountId))
+	}
+
+	return true, nil
+}
+
+func (slvgbdtg *softLayer_Virtual_Guest_Block_Device_Template_Group_Service) PermitSharingAccess(id int, accountId int) (bool, error) {
+	parameters := datatypes.SoftLayer_Virtual_Guest_Block_Device_Template_GroupInitParameters{
+		Parameters: datatypes.SoftLayer_Virtual_Guest_Block_Device_Template_GroupInitParameter{
+			AccountId: accountId,
+		},
+	}
+
+	requestBody, err := json.Marshal(parameters)
+	if err != nil {
+		return false, err
+	}
+
+	response, errorCode, err := slvgbdtg.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/permitSharingAccess.json", slvgbdtg.GetName(), id), "POST", bytes.NewBuffer(requestBody))
+	if err != nil {
+		return false, err
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Virtual_Guest_Block_Device_Template_Group#permitSharingAccess, HTTP error code: '%d'", errorCode)
+		return false, errors.New(errorMessage)
+	}
+
+	if res := string(response[:]); res != "true" {
+		return false, errors.New(fmt.Sprintf("Failed to permit sharing access to VGDBTG with ID: %d to account ID: %d", id, accountId))
+	}
+
+	return true, nil
+}
+
+func (slvgbdtg *softLayer_Virtual_Guest_Block_Device_Template_Group_Service) AddLocations(id int, locations []datatypes.SoftLayer_Location) (bool, error) {
+	parameters := datatypes.SoftLayer_Virtual_Guest_Block_Device_Template_Group_LocationsInitParameters{
+		Parameters: datatypes.SoftLayer_Virtual_Guest_Block_Device_Template_Group_LocationsInitParameter{
+			Locations: locations,
+		},
+	}
+
+	requestBody, err := json.Marshal(parameters)
+	if err != nil {
+		return false, err
+	}
+
+	response, errorCode, err := slvgbdtg.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/addLocations.json", slvgbdtg.GetName(), id), "POST", bytes.NewBuffer(requestBody))
+	if err != nil {
+		return false, err
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Virtual_Guest_Block_Device_Template_Group#addLocations, HTTP error code: '%d'", errorCode)
+		return false, errors.New(errorMessage)
+	}
+
+	if res := string(response[:]); res != "true" {
+		return false, errors.New(fmt.Sprintf("Failed to add locations access to VGDBTG with ID: %d", id))
+	}
+
+	return true, nil
+}
+
+func (slvgbdtg *softLayer_Virtual_Guest_Block_Device_Template_Group_Service) RemoveLocations(id int, locations []datatypes.SoftLayer_Location) (bool, error) {
+	parameters := datatypes.SoftLayer_Virtual_Guest_Block_Device_Template_Group_LocationsInitParameters{
+		Parameters: datatypes.SoftLayer_Virtual_Guest_Block_Device_Template_Group_LocationsInitParameter{
+			Locations: locations,
+		},
+	}
+
+	requestBody, err := json.Marshal(parameters)
+	if err != nil {
+		return false, err
+	}
+
+	response, errorCode, err := slvgbdtg.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/removeLocations.json", slvgbdtg.GetName(), id), "POST", bytes.NewBuffer(requestBody))
+	if err != nil {
+		return false, err
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Virtual_Guest_Block_Device_Template_Group#removeLocations, HTTP error code: '%d'", errorCode)
+		return false, errors.New(errorMessage)
+	}
+
+	if res := string(response[:]); res != "true" {
+		return false, errors.New(fmt.Sprintf("Failed to remove locations access to VGDBTG with ID: %d", id))
+	}
+
+	return true, nil
+}
+
+func (slvgbdtg *softLayer_Virtual_Guest_Block_Device_Template_Group_Service) SetAvailableLocations(id int, locations []datatypes.SoftLayer_Location) (bool, error) {
+	parameters := datatypes.SoftLayer_Virtual_Guest_Block_Device_Template_Group_LocationsInitParameters{
+		Parameters: datatypes.SoftLayer_Virtual_Guest_Block_Device_Template_Group_LocationsInitParameter{
+			Locations: locations,
+		},
+	}
+
+	requestBody, err := json.Marshal(parameters)
+	if err != nil {
+		return false, err
+	}
+
+	response, errorCode, err := slvgbdtg.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/setAvailableLocations.json", slvgbdtg.GetName(), id), "POST", bytes.NewBuffer(requestBody))
+	if err != nil {
+		return false, err
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Virtual_Guest_Block_Device_Template_Group#setAvailableLocations, HTTP error code: '%d'", errorCode)
+		return false, errors.New(errorMessage)
+	}
+
+	if res := string(response[:]); res != "true" {
+		return false, errors.New(fmt.Sprintf("Failed to set available locations access to VGDBTG with ID: %d", id))
+	}
+
+	return true, nil
+}
+
+func (slvgbdtg *softLayer_Virtual_Guest_Block_Device_Template_Group_Service) CreatePublicArchiveTransaction(id int, groupName string, summary string, note string, locations []datatypes.SoftLayer_Location) (int, error) {
+	groupName = url.QueryEscape(groupName)
+	summary = url.QueryEscape(summary)
+	note = url.QueryEscape(note)
+
+	parameters := datatypes.SoftLayer_Virtual_Guest_Block_Device_Template_GroupInitParameters2{
+		Parameters: []interface{}{groupName, summary, note, locations},
+	}
+
+	requestBody, err := json.Marshal(parameters)
+	if err != nil {
+		return 0, err
+	}
+
+	response, errorCode, err := slvgbdtg.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/createPublicArchiveTransaction.json", slvgbdtg.GetName(), id), "POST", bytes.NewBuffer(requestBody))
+	if err != nil {
+		return 0, err
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Virtual_Guest_Block_Device_Template_Group#createPublicArchiveTransaction, HTTP error code: '%d'", errorCode)
+		return 0, errors.New(errorMessage)
+	}
+
+	transactionId, err := strconv.Atoi(string(response[:]))
+	if err != nil {
+		return 0, errors.New(fmt.Sprintf("Failed to createPublicArchiveTransaction for ID: %d, error: %s", id, string(response[:])))
+	}
+
+	return transactionId, nil
+}
+
+func (slvgbdtg *softLayer_Virtual_Guest_Block_Device_Template_Group_Service) GetGlobalIdentifier(id int) (string, error) {
+	response, errorCode, err := slvgbdtg.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/getGlobalIdentifier.json", slvgbdtg.GetName(), id), "GET", new(bytes.Buffer))
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Virtual_Guest_Block_Device_Template_Group#getGlobalIdentifier, HTTP error code: '%d'", errorCode)
+		return "", errors.New(errorMessage)
+	}
+
+	return string(strings.TrimSpace(string(response))), err
+}

--- a/vendor/github.com/TheWeatherCompany/softlayer-go/services/softlayer_billing_item.go
+++ b/vendor/github.com/TheWeatherCompany/softlayer-go/services/softlayer_billing_item.go
@@ -1,0 +1,41 @@
+package services
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	common "github.com/TheWeatherCompany/softlayer-go/common"
+	softlayer "github.com/TheWeatherCompany/softlayer-go/softlayer"
+)
+
+type softLayer_Billing_Item_Service struct {
+	client softlayer.Client
+}
+
+func NewSoftLayer_Billing_Item_Service(client softlayer.Client) *softLayer_Billing_Item_Service {
+	return &softLayer_Billing_Item_Service{
+		client: client,
+	}
+}
+
+func (slbi *softLayer_Billing_Item_Service) GetName() string {
+	return "SoftLayer_Billing_Item"
+}
+
+func (slbi *softLayer_Billing_Item_Service) CancelService(billingId int) (bool, error) {
+	response, errorCode, err := slbi.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/cancelService.json", slbi.GetName(), billingId), "GET", new(bytes.Buffer))
+	if err != nil {
+		return false, err
+	}
+
+	if res := string(response[:]); res != "true" {
+		return false, nil
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Billing_Item#CancelService, HTTP error code: '%d'", errorCode)
+		return false, errors.New(errorMessage)
+	}
+
+	return true, err
+}

--- a/vendor/github.com/TheWeatherCompany/softlayer-go/services/softlayer_billing_item_cancellation_request.go
+++ b/vendor/github.com/TheWeatherCompany/softlayer-go/services/softlayer_billing_item_cancellation_request.go
@@ -1,0 +1,57 @@
+package services
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	common "github.com/TheWeatherCompany/softlayer-go/common"
+	datatypes "github.com/TheWeatherCompany/softlayer-go/data_types"
+	softlayer "github.com/TheWeatherCompany/softlayer-go/softlayer"
+)
+
+type softLayer_Billing_Item_Cancellation_Request_Service struct {
+	client softlayer.Client
+}
+
+func NewSoftLayer_Billing_Item_Cancellation_Request_Service(client softlayer.Client) *softLayer_Billing_Item_Cancellation_Request_Service {
+	return &softLayer_Billing_Item_Cancellation_Request_Service{
+		client: client,
+	}
+}
+
+func (slbicr *softLayer_Billing_Item_Cancellation_Request_Service) GetName() string {
+	return "SoftLayer_Billing_Item_Cancellation_Request"
+}
+
+func (slbicr *softLayer_Billing_Item_Cancellation_Request_Service) CreateObject(request datatypes.SoftLayer_Billing_Item_Cancellation_Request) (datatypes.SoftLayer_Billing_Item_Cancellation_Request, error) {
+	parameters := datatypes.SoftLayer_Billing_Item_Cancellation_Request_Parameters{
+		Parameters: []datatypes.SoftLayer_Billing_Item_Cancellation_Request{
+			request,
+		},
+	}
+
+	requestBody, err := json.Marshal(parameters)
+	if err != nil {
+		return datatypes.SoftLayer_Billing_Item_Cancellation_Request{}, err
+	}
+
+	responseBytes, errorCode, err := slbicr.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/createObject.json", slbicr.GetName()), "POST", bytes.NewBuffer(requestBody))
+	if err != nil {
+		return datatypes.SoftLayer_Billing_Item_Cancellation_Request{}, err
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Billing_Item_Cancellation_Request#createObject TTP error code: '%d'", errorCode)
+		return datatypes.SoftLayer_Billing_Item_Cancellation_Request{}, errors.New(errorMessage)
+	}
+
+	result := datatypes.SoftLayer_Billing_Item_Cancellation_Request{}
+	err = json.Unmarshal(responseBytes, &result)
+	if err != nil {
+		return datatypes.SoftLayer_Billing_Item_Cancellation_Request{}, err
+	}
+
+	return result, nil
+}

--- a/vendor/github.com/TheWeatherCompany/softlayer-go/services/softlayer_dns_domain.go
+++ b/vendor/github.com/TheWeatherCompany/softlayer-go/services/softlayer_dns_domain.go
@@ -1,0 +1,113 @@
+package services
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	common "github.com/TheWeatherCompany/softlayer-go/common"
+	datatypes "github.com/TheWeatherCompany/softlayer-go/data_types"
+	softlayer "github.com/TheWeatherCompany/softlayer-go/softlayer"
+)
+
+type softLayer_Dns_Domain_Service struct {
+	client softlayer.Client
+}
+
+func NewSoftLayer_Dns_Domain_Service(client softlayer.Client) *softLayer_Dns_Domain_Service {
+	return &softLayer_Dns_Domain_Service{
+		client: client,
+	}
+}
+
+func (sldds *softLayer_Dns_Domain_Service) GetName() string {
+	return "SoftLayer_Dns_Domain"
+}
+
+func (sldds *softLayer_Dns_Domain_Service) CreateObject(template datatypes.SoftLayer_Dns_Domain_Template) (datatypes.SoftLayer_Dns_Domain, error) {
+	if template.ResourceRecords == nil {
+		template.ResourceRecords = []datatypes.SoftLayer_Dns_Domain_ResourceRecord{}
+	}
+
+	parameters := datatypes.SoftLayer_Dns_Domain_Template_Parameters{
+		Parameters: []datatypes.SoftLayer_Dns_Domain_Template{
+			template,
+		},
+	}
+
+	requestBody, err := json.Marshal(parameters)
+	if err != nil {
+		return datatypes.SoftLayer_Dns_Domain{}, err
+	}
+
+	response, errorCode, err := sldds.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s.json", sldds.GetName()), "POST", bytes.NewBuffer(requestBody))
+	if err != nil {
+		return datatypes.SoftLayer_Dns_Domain{}, err
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Dns_Domain#createObject, HTTP error code: '%d'", errorCode)
+		return datatypes.SoftLayer_Dns_Domain{}, errors.New(errorMessage)
+	}
+
+	err = sldds.client.GetHttpClient().CheckForHttpResponseErrors(response)
+	if err != nil {
+		return datatypes.SoftLayer_Dns_Domain{}, err
+	}
+
+	softLayer_Dns_Domain := datatypes.SoftLayer_Dns_Domain{}
+	err = json.Unmarshal(response, &softLayer_Dns_Domain)
+	if err != nil {
+		return datatypes.SoftLayer_Dns_Domain{}, err
+	}
+
+	return softLayer_Dns_Domain, nil
+}
+
+func (sldds *softLayer_Dns_Domain_Service) GetObject(dnsId int) (datatypes.SoftLayer_Dns_Domain, error) {
+	objectMask := []string{
+		"id",
+		"name",
+		"serial",
+		"updateDate",
+		"account",
+		"managedResourceFlag",
+		"resourceRecordCount",
+		"resourceRecords",
+		"secondary",
+	}
+
+	response, errorCode, err := sldds.client.GetHttpClient().DoRawHttpRequestWithObjectMask(fmt.Sprintf("%s/%d/getObject.json", sldds.GetName(), dnsId), objectMask, "GET", new(bytes.Buffer))
+	if err != nil {
+		return datatypes.SoftLayer_Dns_Domain{}, err
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Dns_Domain#getObject, HTTP error code: '%d'", errorCode)
+		return datatypes.SoftLayer_Dns_Domain{}, errors.New(errorMessage)
+	}
+
+	dns_domain := datatypes.SoftLayer_Dns_Domain{}
+	err = json.Unmarshal(response, &dns_domain)
+	if err != nil {
+		return datatypes.SoftLayer_Dns_Domain{}, err
+	}
+
+	return dns_domain, nil
+}
+
+func (sldds *softLayer_Dns_Domain_Service) DeleteObject(dnsId int) (bool, error) {
+	response, errorCode, err := sldds.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d.json", sldds.GetName(), dnsId), "DELETE", new(bytes.Buffer))
+
+	if response_value := string(response[:]); response_value != "true" {
+		return false, errors.New(fmt.Sprintf("Failed to delete dns domain with id '%d', got '%s' as response from the API", dnsId, response_value))
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Dns_Domain#deleteObject, HTTP error code: '%d'", errorCode)
+		return false, errors.New(errorMessage)
+	}
+
+	return true, err
+}

--- a/vendor/github.com/TheWeatherCompany/softlayer-go/services/softlayer_dns_domain_resource_record.go
+++ b/vendor/github.com/TheWeatherCompany/softlayer-go/services/softlayer_dns_domain_resource_record.go
@@ -1,0 +1,162 @@
+package services
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	common "github.com/TheWeatherCompany/softlayer-go/common"
+	datatypes "github.com/TheWeatherCompany/softlayer-go/data_types"
+	softlayer "github.com/TheWeatherCompany/softlayer-go/softlayer"
+)
+
+type SoftLayer_Dns_Domain_ResourceRecord_Service struct {
+	client softlayer.Client
+}
+
+func NewSoftLayer_Dns_Domain_ResourceRecord_Service(client softlayer.Client) *SoftLayer_Dns_Domain_ResourceRecord_Service {
+	return &SoftLayer_Dns_Domain_ResourceRecord_Service{
+		client: client,
+	}
+}
+
+func (sldr *SoftLayer_Dns_Domain_ResourceRecord_Service) GetName() string {
+	return "SoftLayer_Dns_Domain_ResourceRecord"
+}
+
+func (sldr *SoftLayer_Dns_Domain_ResourceRecord_Service) CreateObject(template datatypes.SoftLayer_Dns_Domain_ResourceRecord_Template) (datatypes.SoftLayer_Dns_Domain_ResourceRecord, error) {
+	parameters := datatypes.SoftLayer_Dns_Domain_ResourceRecord_Template_Parameters{
+		Parameters: []datatypes.SoftLayer_Dns_Domain_ResourceRecord_Template{
+			template,
+		},
+	}
+
+	requestBody, err := json.Marshal(parameters)
+	if err != nil {
+		return datatypes.SoftLayer_Dns_Domain_ResourceRecord{}, err
+	}
+
+	response, errorCode, err := sldr.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/createObject", sldr.getNameByType(template.Type)), "POST", bytes.NewBuffer(requestBody))
+	if err != nil {
+		return datatypes.SoftLayer_Dns_Domain_ResourceRecord{}, err
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Dns_Domain_ResourceRecord#createObject, HTTP error code: '%d'", errorCode)
+		return datatypes.SoftLayer_Dns_Domain_ResourceRecord{}, errors.New(errorMessage)
+	}
+
+	err = sldr.client.GetHttpClient().CheckForHttpResponseErrors(response)
+	if err != nil {
+		return datatypes.SoftLayer_Dns_Domain_ResourceRecord{}, err
+	}
+
+	dns_record := datatypes.SoftLayer_Dns_Domain_ResourceRecord{}
+	err = json.Unmarshal(response, &dns_record)
+	if err != nil {
+		return datatypes.SoftLayer_Dns_Domain_ResourceRecord{}, err
+	}
+
+	return dns_record, nil
+}
+
+func (sldr *SoftLayer_Dns_Domain_ResourceRecord_Service) GetObject(id int) (datatypes.SoftLayer_Dns_Domain_ResourceRecord, error) {
+	objectMask := []string{
+		"data",
+		"domainId",
+		"expire",
+		"host",
+		"id",
+		"minimum",
+		"mxPriority",
+		"refresh",
+		"responsiblePerson",
+		"retry",
+		"ttl",
+		"type",
+		"service",
+		"priority",
+		"protocol",
+		"port",
+		"weight",
+	}
+
+	response, errorCode, err := sldr.client.GetHttpClient().DoRawHttpRequestWithObjectMask(fmt.Sprintf("%s/%d/getObject.json", sldr.GetName(), id), objectMask, "GET", new(bytes.Buffer))
+	if err != nil {
+		return datatypes.SoftLayer_Dns_Domain_ResourceRecord{}, err
+	}
+
+	err = sldr.client.GetHttpClient().CheckForHttpResponseErrors(response)
+	if err != nil {
+		return datatypes.SoftLayer_Dns_Domain_ResourceRecord{}, err
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Dns_Domain_ResourceRecord#getObject, HTTP error code: '%d'", errorCode)
+		return datatypes.SoftLayer_Dns_Domain_ResourceRecord{}, errors.New(errorMessage)
+	}
+
+	dns_record := datatypes.SoftLayer_Dns_Domain_ResourceRecord{}
+	err = json.Unmarshal(response, &dns_record)
+	if err != nil {
+		return datatypes.SoftLayer_Dns_Domain_ResourceRecord{}, err
+	}
+
+	return dns_record, nil
+}
+
+func (sldr *SoftLayer_Dns_Domain_ResourceRecord_Service) DeleteObject(recordId int) (bool, error) {
+	response, errorCode, err := sldr.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d.json", sldr.GetName(), recordId), "DELETE", new(bytes.Buffer))
+
+	if res := string(response[:]); res != "true" {
+		return false, errors.New(fmt.Sprintf("Failed to delete DNS Domain Record with id '%d', got '%s' as response from the API.", recordId, res))
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Dns_Domain_ResourceRecord#deleteObject, HTTP error code: '%d'", errorCode)
+		return false, errors.New(errorMessage)
+	}
+
+	return true, err
+}
+
+func (sldr *SoftLayer_Dns_Domain_ResourceRecord_Service) EditObject(recordId int, template datatypes.SoftLayer_Dns_Domain_ResourceRecord) (bool, error) {
+	parameters := datatypes.SoftLayer_Dns_Domain_ResourceRecord_Parameters{
+		Parameters: []datatypes.SoftLayer_Dns_Domain_ResourceRecord{
+			template,
+		},
+	}
+
+	requestBody, err := json.Marshal(parameters)
+	if err != nil {
+		return false, err
+	}
+
+	response, errorCode, err := sldr.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/editObject.json", sldr.getNameByType(template.Type), recordId), "POST", bytes.NewBuffer(requestBody))
+
+	if res := string(response[:]); res != "true" {
+		return false, errors.New(fmt.Sprintf("Failed to edit DNS Domain Record with id: %d, got '%s' as response from the API.", recordId, res))
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Dns_Domain_ResourceRecord#editObject, HTTP error code: '%d'", errorCode)
+		return false, errors.New(errorMessage)
+	}
+
+	return true, err
+}
+
+//Private methods
+
+func (sldr *SoftLayer_Dns_Domain_ResourceRecord_Service) getNameByType(dnsType string) string {
+	switch dnsType {
+	case "srv":
+		// Currently only SRV record type requires additional fields for Create and Update, while all other record types
+		// use basic default resource type. Therefore there is no need for now to implement each resource type as separate service
+		// https://sldn.softlayer.com/reference/datatypes/SoftLayer_Dns_Domain_ResourceRecord_SrvType
+		return "SoftLayer_Dns_Domain_ResourceRecord_SrvType"
+	default:
+		return "SoftLayer_Dns_Domain_ResourceRecord"
+	}
+}

--- a/vendor/github.com/TheWeatherCompany/softlayer-go/services/softlayer_hardware.go
+++ b/vendor/github.com/TheWeatherCompany/softlayer-go/services/softlayer_hardware.go
@@ -1,0 +1,429 @@
+package services
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	common "github.com/TheWeatherCompany/softlayer-go/common"
+	datatypes "github.com/TheWeatherCompany/softlayer-go/data_types"
+	softlayer "github.com/TheWeatherCompany/softlayer-go/softlayer"
+)
+
+type softLayer_Hardware_Service struct {
+	client softlayer.Client
+}
+
+func NewSoftLayer_Hardware_Service(client softlayer.Client) *softLayer_Hardware_Service {
+	return &softLayer_Hardware_Service{
+		client: client,
+	}
+}
+
+func (slhs *softLayer_Hardware_Service) GetName() string {
+	return "SoftLayer_Hardware"
+}
+
+func (slhs *softLayer_Hardware_Service) AllowAccessToNetworkStorage(id int, storage datatypes.SoftLayer_Network_Storage) (bool, error) {
+	parameters := datatypes.SoftLayer_Hardware_NetworkStorage_Parameters{
+		Parameters: storage,
+	}
+
+	requestBody, err := json.Marshal(parameters)
+	if err != nil {
+		return false, err
+	}
+
+	response, errorCode, err := slhs.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/allowAccessToNetworkStorage.json", slhs.GetName(), id), "POST", bytes.NewBuffer(requestBody))
+	if err != nil {
+		return false, err
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Hardware#allowAccessToNetworkStorage, HTTP error code: '%d'", errorCode)
+		return false, errors.New(errorMessage)
+	}
+
+	if res := string(response[:]); res != "true" {
+		return false, errors.New(fmt.Sprintf("Failed to allowAccessToNetworkStorage with id '%d', got '%s' as response from the API.", id, res))
+	}
+
+	return true, nil
+}
+
+func (slhs *softLayer_Hardware_Service) CreateObject(template datatypes.SoftLayer_Hardware_Template) (datatypes.SoftLayer_Hardware, error) {
+	parameters := datatypes.SoftLayer_Hardware_Template_Parameters{
+		Parameters: []datatypes.SoftLayer_Hardware_Template{
+			template,
+		},
+	}
+
+	requestBody, err := json.Marshal(parameters)
+	if err != nil {
+		return datatypes.SoftLayer_Hardware{}, err
+	}
+
+	response, errorCode, err := slhs.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s.json", slhs.GetName()), "POST", bytes.NewBuffer(requestBody))
+	if err != nil {
+		return datatypes.SoftLayer_Hardware{}, err
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Hardware#createObject, HTTP error code: '%d'", errorCode)
+		return datatypes.SoftLayer_Hardware{}, errors.New(errorMessage)
+	}
+
+	err = slhs.client.GetHttpClient().CheckForHttpResponseErrors(response)
+	if err != nil {
+		return datatypes.SoftLayer_Hardware{}, err
+	}
+
+	hardware := datatypes.SoftLayer_Hardware{}
+	err = json.Unmarshal(response, &hardware)
+	if err != nil {
+		return datatypes.SoftLayer_Hardware{}, err
+	}
+
+	return hardware, nil
+}
+
+func (slhs *softLayer_Hardware_Service) FindByIpAddress(ipAddress string) (datatypes.SoftLayer_Hardware, error) {
+
+	ipAddressParameters := datatypes.SoftLayer_Hardware_String_Parameters{
+		Parameters: []string{ipAddress},
+	}
+
+	requestBody, err := json.Marshal(ipAddressParameters)
+	if err != nil {
+		return datatypes.SoftLayer_Hardware{}, err
+	}
+
+	objectMask := []string{
+		"bareMetalInstanceFlag",
+		"domain",
+		"hostname",
+		"id",
+		"hardwareStatusId",
+		"provisionDate",
+		"globalIdentifier",
+		"primaryIpAddress",
+		"operatingSystem.passwords.password",
+		"operatingSystem.passwords.username",
+		"datacenter.name",
+		"datacenter.longName",
+		"datacenter.id",
+	}
+
+	response, errorCode, err := slhs.client.GetHttpClient().DoRawHttpRequestWithObjectMask(fmt.Sprintf("%s/findByIpAddress.json", slhs.GetName()), objectMask, "POST", bytes.NewBuffer(requestBody))
+	if err != nil {
+		return datatypes.SoftLayer_Hardware{}, err
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Hardware#findByIpAddress, HTTP error code: '%d'", errorCode)
+		return datatypes.SoftLayer_Hardware{}, errors.New(errorMessage)
+	}
+
+	hardware := datatypes.SoftLayer_Hardware{}
+	err = json.Unmarshal(response, &hardware)
+	if err != nil {
+		return datatypes.SoftLayer_Hardware{}, err
+	}
+
+	return hardware, nil
+}
+
+func (slhs *softLayer_Hardware_Service) GetObject(id int) (datatypes.SoftLayer_Hardware, error) {
+
+	objectMask := []string{
+		"bareMetalInstanceFlag",
+		"domain",
+		"hostname",
+		"id",
+		"hardwareStatusId",
+		"provisionDate",
+		"globalIdentifier",
+		"primaryIpAddress",
+		"operatingSystem.passwords.password",
+		"operatingSystem.passwords.username",
+		"datacenter.name",
+		"datacenter.longName",
+		"datacenter.id",
+	}
+
+	response, errorCode, err := slhs.client.GetHttpClient().DoRawHttpRequestWithObjectMask(fmt.Sprintf("%s/%d/getObject.json", slhs.GetName(), id), objectMask, "GET", new(bytes.Buffer))
+	if err != nil {
+		return datatypes.SoftLayer_Hardware{}, err
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Hardware#getObject, HTTP error code: '%d'", errorCode)
+		return datatypes.SoftLayer_Hardware{}, errors.New(errorMessage)
+	}
+
+	err = slhs.client.GetHttpClient().CheckForHttpResponseErrors(response)
+	if err != nil {
+		return datatypes.SoftLayer_Hardware{}, err
+	}
+
+	hardware := datatypes.SoftLayer_Hardware{}
+	err = json.Unmarshal(response, &hardware)
+	if err != nil {
+		return datatypes.SoftLayer_Hardware{}, err
+	}
+
+	return hardware, nil
+}
+
+func (slhs *softLayer_Hardware_Service) GetAttachedNetworkStorages(id int, nasType string) ([]datatypes.SoftLayer_Network_Storage, error) {
+
+	nasTypeParameters := datatypes.SoftLayer_Hardware_String_Parameters{
+		Parameters: []string{nasType},
+	}
+
+	requestBody, err := json.Marshal(nasTypeParameters)
+	if err != nil {
+		return []datatypes.SoftLayer_Network_Storage{}, err
+	}
+
+	objectMask := []string{
+		"accountId",
+		"capacityGb",
+		"createDate",
+		"guestId",
+		"hardwareId",
+		"hostId",
+		"id",
+		"nasType",
+		"notes",
+		"Password",
+		"serviceProviderId",
+		"upgradableFlag",
+		"username",
+		"billingItem.id",
+		"billingItem.orderItem.order.id",
+		"lunId",
+		"serviceResourceBackendIpAddress",
+	}
+
+	response, errorCode, err := slhs.client.GetHttpClient().DoRawHttpRequestWithObjectMask(fmt.Sprintf("%s/%d/getAttachedNetworkStorages.json", slhs.GetName(), id), objectMask, "POST", bytes.NewBuffer(requestBody))
+	if err != nil {
+		return []datatypes.SoftLayer_Network_Storage{}, err
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Hardware#getAttachedNetworkStorages, HTTP error code: '%d'", errorCode)
+		return []datatypes.SoftLayer_Network_Storage{}, errors.New(errorMessage)
+	}
+
+	err = slhs.client.GetHttpClient().CheckForHttpResponseErrors(response)
+	if err != nil {
+		return []datatypes.SoftLayer_Network_Storage{}, err
+	}
+
+	storageList := []datatypes.SoftLayer_Network_Storage{}
+	err = json.Unmarshal(response, &storageList)
+	if err != nil {
+		return []datatypes.SoftLayer_Network_Storage{}, err
+	}
+
+	return storageList, nil
+}
+
+func (slhs *softLayer_Hardware_Service) GetAllowedHost(id int) (datatypes.SoftLayer_Network_Storage_Allowed_Host, error) {
+	response, errorCode, err := slhs.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/getAllowedHost.json", slhs.GetName(), id), "GET", new(bytes.Buffer))
+	if err != nil {
+		return datatypes.SoftLayer_Network_Storage_Allowed_Host{}, err
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Hardware#getAllowedHost, HTTP error code: '%d'", errorCode)
+		return datatypes.SoftLayer_Network_Storage_Allowed_Host{}, errors.New(errorMessage)
+	}
+
+	allowedHost := datatypes.SoftLayer_Network_Storage_Allowed_Host{}
+	err = json.Unmarshal(response, &allowedHost)
+	if err != nil {
+		return datatypes.SoftLayer_Network_Storage_Allowed_Host{}, err
+	}
+
+	return allowedHost, nil
+}
+
+func (slhs *softLayer_Hardware_Service) GetDatacenter(id int) (datatypes.SoftLayer_Location, error) {
+	response, errorCode, err := slhs.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/getDatacenter.json", slhs.GetName(), id), "GET", new(bytes.Buffer))
+	if err != nil {
+		return datatypes.SoftLayer_Location{}, err
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Hardware#getDatacenter, HTTP error code: '%d'", errorCode)
+		return datatypes.SoftLayer_Location{}, errors.New(errorMessage)
+	}
+
+	datacenter := datatypes.SoftLayer_Location{}
+	err = json.Unmarshal(response, &datacenter)
+	if err != nil {
+		return datatypes.SoftLayer_Location{}, err
+	}
+
+	return datacenter, nil
+}
+
+func (slhs *softLayer_Hardware_Service) GetPrimaryIpAddress(id int) (string, error) {
+	response, errorCode, err := slhs.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/getPrimaryIpAddress.json", slhs.GetName(), id), "GET", new(bytes.Buffer))
+	if err != nil {
+		return "", err
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Hardware#getPrimaryIpAddress, HTTP error code: '%d'", errorCode)
+		return "", errors.New(errorMessage)
+	}
+
+	return string(response[:]), nil
+}
+
+func (slhs *softLayer_Hardware_Service) PowerOff(instanceId int) (bool, error) {
+	response, errorCode, err := slhs.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/powerOff.json", slhs.GetName(), instanceId), "GET", new(bytes.Buffer))
+	if err != nil {
+		return false, err
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Hardware#powerOff, HTTP error code: '%d'", errorCode)
+		return false, errors.New(errorMessage)
+	}
+
+	if res := string(response[:]); res != "true" {
+		return false, errors.New(fmt.Sprintf("Failed to power off hardware with id '%d', got '%s' as response from the API.", instanceId, res))
+	}
+
+	return true, nil
+}
+
+func (slhs *softLayer_Hardware_Service) PowerOffSoft(instanceId int) (bool, error) {
+	response, errorCode, err := slhs.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/powerOffSoft.json", slhs.GetName(), instanceId), "GET", new(bytes.Buffer))
+	if err != nil {
+		return false, err
+	}
+
+	if res := string(response[:]); res != "true" {
+		return false, errors.New(fmt.Sprintf("Failed to power off soft hardware with id '%d', got '%s' as response from the API.", instanceId, res))
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Hardware#powerOffSoft, HTTP error code: '%d'", errorCode)
+		return false, errors.New(errorMessage)
+	}
+
+	return true, nil
+}
+
+func (slhs *softLayer_Hardware_Service) PowerOn(instanceId int) (bool, error) {
+	response, errorCode, err := slhs.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/powerOn.json", slhs.GetName(), instanceId), "GET", new(bytes.Buffer))
+	if err != nil {
+		return false, err
+	}
+
+	if res := string(response[:]); res != "true" {
+		return false, errors.New(fmt.Sprintf("Failed to power on hardware with id '%d', got '%s' as response from the API.", instanceId, res))
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Hardware#powerOn, HTTP error code: '%d'", errorCode)
+		return false, errors.New(errorMessage)
+	}
+
+	return true, nil
+}
+
+func (slhs *softLayer_Hardware_Service) RebootDefault(instanceId int) (bool, error) {
+	response, errorCode, err := slhs.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/rebootDefault.json", slhs.GetName(), instanceId), "GET", new(bytes.Buffer))
+	if err != nil {
+		return false, err
+	}
+
+	if res := string(response[:]); res != "true" {
+		return false, errors.New(fmt.Sprintf("Failed to default reboot hardware with id '%d', got '%s' as response from the API.", instanceId, res))
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Hardware#rebootDefault, HTTP error code: '%d'", errorCode)
+		return false, errors.New(errorMessage)
+	}
+
+	return true, nil
+}
+
+func (slhs *softLayer_Hardware_Service) RebootSoft(instanceId int) (bool, error) {
+	response, errorCode, err := slhs.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/rebootSoft.json", slhs.GetName(), instanceId), "GET", new(bytes.Buffer))
+	if err != nil {
+		return false, err
+	}
+
+	if res := string(response[:]); res != "true" {
+		return false, errors.New(fmt.Sprintf("Failed to soft reboot hardware with id '%d', got '%s' as response from the API.", instanceId, res))
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Hardware#rebootSoft, HTTP error code: '%d'", errorCode)
+		return false, errors.New(errorMessage)
+	}
+
+	return true, nil
+}
+
+func (slhs *softLayer_Hardware_Service) RebootHard(instanceId int) (bool, error) {
+	response, errorCode, err := slhs.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/rebootHard.json", slhs.GetName(), instanceId), "GET", new(bytes.Buffer))
+	if err != nil {
+		return false, err
+	}
+
+	if res := string(response[:]); res != "true" {
+		return false, errors.New(fmt.Sprintf("Failed to hard reboot hardware with id '%d', got '%s' as response from the API.", instanceId, res))
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Hardware#rebootHard, HTTP error code: '%d'", errorCode)
+		return false, errors.New(errorMessage)
+	}
+
+	return true, nil
+}
+
+func (slhs *softLayer_Hardware_Service) SetTags(instanceId int, tags []string) (bool, error) {
+	var tagStringBuffer bytes.Buffer
+	for i, tag := range tags {
+		tagStringBuffer.WriteString(tag)
+		if i != len(tags)-1 {
+			tagStringBuffer.WriteString(", ")
+		}
+	}
+
+	setTagsParameters := datatypes.SoftLayer_Hardware_String_Parameters{
+		Parameters: []string{tagStringBuffer.String()},
+	}
+
+	requestBody, err := json.Marshal(setTagsParameters)
+	if err != nil {
+		return false, err
+	}
+
+	response, errorCode, err := slhs.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/setTags.json", slhs.GetName(), instanceId), "POST", bytes.NewBuffer(requestBody))
+	if err != nil {
+		return false, err
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Hardware#setTags, HTTP error code: '%d'", errorCode)
+		return false, errors.New(errorMessage)
+	}
+
+	if res := string(response[:]); res != "true" {
+		return false, errors.New(fmt.Sprintf("Failed to setTags for hardware with id '%d', got '%s' as response from the API.", instanceId, res))
+	}
+
+	return true, nil
+}

--- a/vendor/github.com/TheWeatherCompany/softlayer-go/services/softlayer_network_application_delivery_controller.go
+++ b/vendor/github.com/TheWeatherCompany/softlayer-go/services/softlayer_network_application_delivery_controller.go
@@ -1,0 +1,605 @@
+package services
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"github.com/TheWeatherCompany/softlayer-go/common"
+	datatypes "github.com/TheWeatherCompany/softlayer-go/data_types"
+	softlayer "github.com/TheWeatherCompany/softlayer-go/softlayer"
+	"github.com/hashicorp/terraform/helper/resource"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	PACKAGE_TYPE_APPLICATION_DELIVERY_CONTROLLER = "ADDITIONAL_SERVICES_APPLICATION_DELIVERY_APPLIANCE"
+	ORDER_TYPE_APPLICATION_DELIVERY_CONTROLLER   = "SoftLayer_Container_Product_Order_Network_Application_Delivery_Controller"
+	PACKAGE_ID_APPLICATION_DELIVERY_CONTROLLER   = 192
+	DELIMITER                                    = "_"
+	ID_DELIMITER                                 = ";"
+)
+
+type softLayer_Network_Application_Delivery_Controller_Service struct {
+	client softlayer.Client
+}
+
+func NewSoftLayer_Network_Application_Delivery_Controller_Service(client softlayer.Client) *softLayer_Network_Application_Delivery_Controller_Service {
+	return &softLayer_Network_Application_Delivery_Controller_Service{
+		client: client,
+	}
+}
+
+func (slnadcs *softLayer_Network_Application_Delivery_Controller_Service) GetName() string {
+	return "SoftLayer_Network_Application_Delivery_Controller"
+}
+
+func (slnadcs *softLayer_Network_Application_Delivery_Controller_Service) CreateNetscalerVPX(createOptions *softlayer.NetworkApplicationDeliveryControllerCreateOptions) (datatypes.SoftLayer_Network_Application_Delivery_Controller, error) {
+	err := slnadcs.checkCreateVpxRequiredValues(createOptions)
+	if err != nil {
+		return datatypes.SoftLayer_Network_Application_Delivery_Controller{}, err
+	}
+
+	orderService, err := slnadcs.client.GetSoftLayer_Product_Order_Service()
+	if err != nil {
+		return datatypes.SoftLayer_Network_Application_Delivery_Controller{}, err
+	}
+
+	items, err := slnadcs.FindCreatePriceItems(createOptions)
+	if err != nil {
+		return datatypes.SoftLayer_Network_Application_Delivery_Controller{}, err
+	}
+
+	order := datatypes.SoftLayer_Container_Product_Order_Network_Application_Delivery_Controller{
+		PackageId:   PACKAGE_ID_APPLICATION_DELIVERY_CONTROLLER,
+		ComplexType: ORDER_TYPE_APPLICATION_DELIVERY_CONTROLLER,
+		Location:    createOptions.Location,
+		Prices:      items,
+		Quantity:    1,
+	}
+
+	receipt, err := orderService.PlaceContainerOrderApplicationDeliveryController(order)
+	if err != nil {
+		return datatypes.SoftLayer_Network_Application_Delivery_Controller{}, err
+	}
+
+	vpx, err := slnadcs.findVPXByOrderId(receipt.OrderId)
+	if err != nil {
+		return datatypes.SoftLayer_Network_Application_Delivery_Controller{}, err
+	}
+
+	return vpx, nil
+}
+
+func (slnadcs *softLayer_Network_Application_Delivery_Controller_Service) CreateVirtualIpAddress(nadcId int, template datatypes.SoftLayer_Network_LoadBalancer_VirtualIpAddress_Template) (bool, error) {
+	nadc, err := slnadcs.GetObject(nadcId)
+	if err != nil {
+		return false, err
+	}
+	if nadc.Id != nadcId {
+		return false, fmt.Errorf("Network application delivery controller with id '%d' is not found", nadcId)
+	}
+
+	parameters := datatypes.SoftLayer_Network_LoadBalancer_VirtualIpAddress_Template_Parameters{
+		Parameters: []datatypes.SoftLayer_Network_LoadBalancer_VirtualIpAddress_Template{
+			template,
+		},
+	}
+
+	requestBody, err := json.Marshal(parameters)
+	if err != nil {
+		return false, fmt.Errorf("Network application delivery controller with id '%d' is not found: %s", nadcId, err)
+	}
+
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"{\"error\":\"Method has not been implemented for this object type.\",\"code\":\"SoftLayer_Exception\"}",
+			"{\"error\":\"Could not connect to host\",\"code\":\"HTTP\"}"},
+		Target: []string{"complete"},
+		Refresh: func() (interface{}, string, error) {
+			response, errorCode, error := slnadcs.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/%s.json", slnadcs.GetName(), nadcId, "createLiveLoadBalancer"), "POST", bytes.NewBuffer(requestBody))
+
+			if error != nil {
+				return false, "", err
+			} else if errorCode == 500 {
+				return nil, string(response), nil
+			} else {
+				return true, "complete", nil
+			}
+		},
+		Timeout:    10 * time.Minute,
+		Delay:      5 * time.Second,
+		MinTimeout: 3 * time.Second,
+	}
+
+	pendingResult, err := stateConf.WaitForState()
+
+	if err != nil {
+		return false, err
+	}
+
+	if !bool(pendingResult.(bool)) {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+func (slnadcs *softLayer_Network_Application_Delivery_Controller_Service) CreateLoadBalancerService(vipId string, nadcId int, template []datatypes.SoftLayer_Network_LoadBalancer_Service_Template) (bool, error) {
+	_, err := slnadcs.GetVirtualIpAddress(nadcId, vipId)
+
+	if err != nil {
+		return false, fmt.Errorf("Error fetching Virtual Ip Address: %s", err)
+	}
+
+	parameters := datatypes.SoftLayer_Network_LoadBalancer_Service_Parameters{
+		Parameters: []datatypes.SoftLayer_Network_LoadBalancer_Service_VipName_Services{{
+			VipName:  vipId,
+			Services: template,
+		}},
+	}
+
+	requestBody, err := json.Marshal(parameters)
+	if err != nil {
+		return false, fmt.Errorf("Unable to create JSON: %s", err)
+	}
+
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"{\"error\":\"Method has not been implemented for this object type.\",\"code\":\"SoftLayer_Exception\"}",
+			"{\"error\":\"Could not connect to host\",\"code\":\"HTTP\"}"},
+		Target: []string{"complete"},
+		Refresh: func() (interface{}, string, error) {
+			response, errorCode, error := slnadcs.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/%s.json", slnadcs.GetName(), nadcId, "updateLiveLoadBalancer"), "POST", bytes.NewBuffer(requestBody))
+
+			if error != nil {
+				return false, "", err
+			} else if errorCode == 500 {
+				return nil, string(response), nil
+			} else {
+				return true, "complete", nil
+			}
+		},
+		Timeout:    10 * time.Minute,
+		Delay:      5 * time.Second,
+		MinTimeout: 3 * time.Second,
+	}
+
+	pendingResult, err := stateConf.WaitForState()
+
+	if err != nil {
+		return false, err
+	}
+
+	if !bool(pendingResult.(bool)) {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+func (slnadcs *softLayer_Network_Application_Delivery_Controller_Service) DeleteVirtualIpAddress(nadcId int, name string) (bool, error) {
+	nadc, err := slnadcs.GetObject(nadcId)
+	if err != nil {
+		return false, err
+	}
+	if nadc.Id != nadcId {
+		return false, fmt.Errorf("Network application delivery controller with id '%d' is not found", nadcId)
+	}
+
+	parameters := datatypes.SoftLayer_Network_LoadBalancer_VirtualIpAddress_Template_Parameters{
+		Parameters: []datatypes.SoftLayer_Network_LoadBalancer_VirtualIpAddress_Template{
+			datatypes.SoftLayer_Network_LoadBalancer_VirtualIpAddress_Template{
+				Name: name,
+			},
+		},
+	}
+
+	requestBody, err := json.Marshal(parameters)
+	if err != nil {
+		return false, err
+	}
+
+	response, errorCode, err := slnadcs.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/%s.json", slnadcs.GetName(), nadcId, "deleteLiveLoadBalancer"), "POST", bytes.NewBuffer(requestBody))
+	if err != nil {
+		errorMessage := fmt.Sprintf("softlayer-go: could not perform SoftLayer_Network_Application_Delivery_Controller#deleteVirtualIpAddress, error message '%s'", err.Error())
+		return false, errors.New(errorMessage)
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not perform SoftLayer_Network_Application_Delivery_Controller#deleteVirtualIpAddress, HTTP error code: '%d'", errorCode)
+		return false, errors.New(errorMessage)
+	}
+
+	if response_value := string(response[:]); response_value != "true" {
+		return false, fmt.Errorf("Failed to delete Virtual IP Address with name '%s' from network application delivery controller with id '%d'. Got '%s' as response from the API", name, nadcId, response_value)
+	}
+
+	return true, err
+}
+
+func (slnadcs *softLayer_Network_Application_Delivery_Controller_Service) DeleteLoadBalancerService(nadcId int, vipId string, serviceId string) (bool, error) {
+	vip, err := slnadcs.GetVirtualIpAddress(nadcId, vipId)
+	if err != nil {
+		return false, err
+	}
+	if vip.Name != vipId {
+		return false, fmt.Errorf("VIP with ID '%s' is not found", vipId)
+	}
+
+	parameters := datatypes.SoftLayer_Network_LoadBalancer_Service_Parameters_Delete{
+		Parameters: []datatypes.SoftLayer_Network_LoadBalancer_Service_VipName_Services_Delete{{
+			ServiceName: serviceId,
+			Vip: datatypes.SoftLayer_Network_LoadBalancer_Service_VipName{
+				VipName: vipId,
+			},
+		}},
+	}
+
+	requestBody, err := json.Marshal(parameters)
+	if err != nil {
+		return false, fmt.Errorf("Unable to create JSON: %s", err)
+	}
+
+	response, errorCode, err := slnadcs.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/%s.json", slnadcs.GetName(), nadcId, "deleteLiveLoadBalancerService"), "POST", bytes.NewBuffer(requestBody))
+	if err != nil {
+		errorMessage := fmt.Sprintf("softlayer-go: could not perform SoftLayer_Network_Application_Delivery_Controller#deleteLiveLoadBalancerService, error message '%s'", err.Error())
+		return false, errors.New(errorMessage)
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not perform SoftLayer_Network_Application_Delivery_Controller#deleteLiveLoadBalancerService, HTTP error code: '%d'", errorCode)
+		return false, errors.New(errorMessage)
+	}
+
+	if response_value := string(response[:]); response_value != "true" {
+		return false, fmt.Errorf("Failed to delete LoadBalancerService with name '%s' from network application delivery controller with id '%d'. Got '%s' as response from the API", serviceId, nadcId, response_value)
+	}
+
+	return true, err
+}
+
+func (slnadcs *softLayer_Network_Application_Delivery_Controller_Service) EditVirtualIpAddress(nadcId int, template datatypes.SoftLayer_Network_LoadBalancer_VirtualIpAddress_Template) (bool, error) {
+	nadc, err := slnadcs.GetObject(nadcId)
+	if err != nil {
+		return false, err
+	}
+	if nadc.Id != nadcId {
+		return false, fmt.Errorf("Network application delivery controller with id '%d' is not found", nadcId)
+	}
+
+	parameters := datatypes.SoftLayer_Network_LoadBalancer_VirtualIpAddress_Template_Parameters{
+		Parameters: []datatypes.SoftLayer_Network_LoadBalancer_VirtualIpAddress_Template{
+			template,
+		},
+	}
+
+	requestBody, err := json.Marshal(parameters)
+	if err != nil {
+		return false, err
+	}
+
+	response, errorCode, err := slnadcs.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/%s.json", slnadcs.GetName(), nadcId, "updateLiveLoadBalancer"), "POST", bytes.NewBuffer(requestBody))
+	if err != nil {
+		errorMessage := fmt.Sprintf("softlayer-go: could not perform SoftLayer_Network_Application_Delivery_Controller#editVirtualIpAddress, error message '%s'", err.Error())
+		return false, errors.New(errorMessage)
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not perform SoftLayer_Network_Application_Delivery_Controller#editVirtualIpAddress, HTTP error code: '%d'", errorCode)
+		return false, errors.New(errorMessage)
+	}
+
+	if response_value := string(response[:]); response_value != "true" {
+		return false, fmt.Errorf("Failed to update Virtual IP Address with id '%d' from network application delivery controller with id '%d'. Got '%s' as response from the API", template.Id, nadcId, response_value)
+	}
+
+	return true, err
+}
+
+func (slnadcs *softLayer_Network_Application_Delivery_Controller_Service) GetVirtualIpAddress(nadcId int, vipName string) (datatypes.SoftLayer_Network_LoadBalancer_VirtualIpAddress, error) {
+	nadc, err := slnadcs.GetObject(nadcId)
+	if err != nil {
+		return datatypes.SoftLayer_Network_LoadBalancer_VirtualIpAddress{}, err
+	}
+	if nadc.Id != nadcId {
+		return datatypes.SoftLayer_Network_LoadBalancer_VirtualIpAddress{}, fmt.Errorf("Network application delivery controller with id '%d' is not found", nadcId)
+	}
+
+	response, errorCode, err := slnadcs.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/%s.json", slnadcs.GetName(), nadcId, "getLoadBalancers"), "GET", new(bytes.Buffer))
+	if err != nil {
+		errorMessage := fmt.Sprintf("softlayer-go: could not perform SoftLayer_Network_Application_Delivery_Controller#getVirtualIpAddress, error message '%s'", err.Error())
+		return datatypes.SoftLayer_Network_LoadBalancer_VirtualIpAddress{}, errors.New(errorMessage)
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not perform SoftLayer_Network_Application_Delivery_Controller#getVirtualIpAddress, HTTP error code: '%d'", errorCode)
+		return datatypes.SoftLayer_Network_LoadBalancer_VirtualIpAddress{}, errors.New(errorMessage)
+	}
+
+	addresses := datatypes.SoftLayer_Network_LoadBalancer_VirtualIpAddress_Array{}
+	err = json.Unmarshal(response, &addresses)
+	if err != nil {
+		return datatypes.SoftLayer_Network_LoadBalancer_VirtualIpAddress{}, err
+	}
+
+	var result datatypes.SoftLayer_Network_LoadBalancer_VirtualIpAddress
+	for _, address := range addresses {
+		if address.Name == vipName {
+			result = address
+			break
+		}
+	}
+
+	return result, err
+}
+
+func (slnadcs *softLayer_Network_Application_Delivery_Controller_Service) GetLoadBalancerService(nadcId int, vipId string, serviceId string) (datatypes.SoftLayer_Network_LoadBalancer_Service, error) {
+	vip, err := slnadcs.GetVirtualIpAddress(nadcId, vipId)
+
+	var result datatypes.SoftLayer_Network_LoadBalancer_Service
+
+	if err != nil {
+		return result, fmt.Errorf("Error fetching Virtual Ip Address: %s", err)
+	}
+
+	for _, service := range vip.Services {
+		if service.Name == serviceId {
+			result = service
+			break
+		}
+	}
+
+	return result, nil
+}
+
+func (slnadcs *softLayer_Network_Application_Delivery_Controller_Service) GetObject(id int) (datatypes.SoftLayer_Network_Application_Delivery_Controller, error) {
+
+	objectMask := []string{
+		"id",
+		"createDate",
+		"name",
+		"typeId",
+		"modifyDate",
+		"description",
+		"managedResourceFlag",
+		"managementIpAddress",
+		"primaryIpAddress",
+		"password",
+		"notes",
+		"datacenter",
+		"averageDailyPublicBandwidthUsage",
+		"licenseExpirationDate",
+		"networkVlan",
+		"networkVlanCount",
+		"networkVlans",
+		"subnetCount",
+		"subnets",
+		"tagReferenceCount",
+		"tagReferences",
+		"type",
+		"virtualIpAddressCount",
+		"virtualIpAddresses",
+	}
+
+	response, errorCode, err := slnadcs.client.GetHttpClient().DoRawHttpRequestWithObjectMask(fmt.Sprintf("%s/%d/getObject.json", slnadcs.GetName(), id), objectMask, "GET", new(bytes.Buffer))
+	if err != nil {
+		errorMessage := fmt.Sprintf("softlayer-go: could not perform SoftLayer_Network_Application_Delivery_Controller#getObject, error message '%s'", err.Error())
+		return datatypes.SoftLayer_Network_Application_Delivery_Controller{}, errors.New(errorMessage)
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not perform SoftLayer_Network_Application_Delivery_Controller#getObject, HTTP error code: '%d'", errorCode)
+		return datatypes.SoftLayer_Network_Application_Delivery_Controller{}, errors.New(errorMessage)
+	}
+
+	nadc := datatypes.SoftLayer_Network_Application_Delivery_Controller{}
+	err = json.Unmarshal(response, &nadc)
+	if err != nil {
+		return datatypes.SoftLayer_Network_Application_Delivery_Controller{}, err
+	}
+
+	return nadc, nil
+}
+
+func (slnadcs *softLayer_Network_Application_Delivery_Controller_Service) GetBillingItem(volumeId int) (datatypes.SoftLayer_Billing_Item, error) {
+
+	response, errorCode, err := slnadcs.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/getBillingItem.json", slnadcs.GetName(), volumeId), "GET", new(bytes.Buffer))
+	if err != nil {
+		return datatypes.SoftLayer_Billing_Item{}, err
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_NetWork_Storage#getBillingItem, HTTP error code: '%d'", errorCode)
+		return datatypes.SoftLayer_Billing_Item{}, errors.New(errorMessage)
+	}
+
+	billingItem := datatypes.SoftLayer_Billing_Item{}
+	err = json.Unmarshal(response, &billingItem)
+	if err != nil {
+		return datatypes.SoftLayer_Billing_Item{}, err
+	}
+
+	return billingItem, nil
+}
+
+func (slnadcs *softLayer_Network_Application_Delivery_Controller_Service) DeleteObject(id int) (bool, error) {
+	billingItem, err := slnadcs.GetBillingItem(id)
+	if err != nil {
+		return false, err
+	}
+
+	if billingItem.Id > 0 {
+		billingItemService, err := slnadcs.client.GetSoftLayer_Billing_Item_Service()
+		if err != nil {
+			return false, err
+		}
+
+		deleted, err := billingItemService.CancelService(billingItem.Id)
+		if err != nil {
+			return false, err
+		}
+
+		if deleted {
+			return false, nil
+		}
+	}
+
+	return true, fmt.Errorf("softlayer-go: could not SoftLayer_Network_Storage_Service#deleteIscsiVolume with id: '%d'", id)
+}
+
+func (slnadcs *softLayer_Network_Application_Delivery_Controller_Service) CancelService(billingId int) (bool, error) {
+	response, errorCode, err := slnadcs.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/cancelService.json", slnadcs.GetName(), billingId), "GET", new(bytes.Buffer))
+	if err != nil {
+		return false, err
+	}
+
+	if res := string(response[:]); res != "true" {
+		return false, nil
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Billing_Item#CancelService, HTTP error code: '%d'", errorCode)
+		return false, errors.New(errorMessage)
+	}
+
+	return true, err
+}
+
+func (slnadcs *softLayer_Network_Application_Delivery_Controller_Service) FindCreatePriceItems(createOptions *softlayer.NetworkApplicationDeliveryControllerCreateOptions) ([]datatypes.SoftLayer_Product_Item_Price, error) {
+	items, err := slnadcs.getApplicationDeliveryControllerItems()
+	if err != nil {
+		return []datatypes.SoftLayer_Product_Item_Price{}, err
+	}
+
+	nadcKey := slnadcs.getVPXPriceItemKeyName(createOptions.Version, createOptions.Speed, createOptions.Plan)
+	ipKey := slnadcs.getPublicIpItemKeyName(createOptions.IpCount)
+
+	var nadcItemPrice, ipItemPrice datatypes.SoftLayer_Product_Item_Price
+
+	for _, item := range items {
+		itemKey := item.Key
+		if itemKey == nadcKey {
+			nadcItemPrice = item.Prices[0]
+		}
+		if itemKey == ipKey {
+			ipItemPrice = item.Prices[0]
+		}
+	}
+
+	var errorMessages []string
+
+	if nadcItemPrice.Id == 0 {
+		errorMessages = append(errorMessages, fmt.Sprintf("VPX version, speed or plan have incorrect values"))
+	}
+
+	if ipItemPrice.Id == 0 {
+		errorMessages = append(errorMessages, fmt.Sprintf("Ip quantity value is incorrect"))
+	}
+
+	if len(errorMessages) > 0 {
+		err = errors.New(strings.Join(errorMessages, "\n"))
+		return []datatypes.SoftLayer_Product_Item_Price{}, err
+	}
+
+	return []datatypes.SoftLayer_Product_Item_Price{nadcItemPrice, ipItemPrice}, nil
+}
+
+// Private methods
+
+func (slnadcs *softLayer_Network_Application_Delivery_Controller_Service) checkCreateVpxRequiredValues(createOptions *softlayer.NetworkApplicationDeliveryControllerCreateOptions) error {
+	var err error
+	var errorMessages []string
+	errorTemplate := "* %s is required and cannot be empty\n"
+
+	if createOptions.Plan == "" {
+		errorMessages = append(errorMessages, fmt.Sprintf(errorTemplate, "Vpx Plan"))
+	}
+
+	if createOptions.Speed <= 0 {
+		errorMessages = append(errorMessages, fmt.Sprintf(errorTemplate, "Network speed"))
+	}
+
+	if createOptions.Version == "" {
+		errorMessages = append(errorMessages, fmt.Sprintf(errorTemplate, "Vpx version"))
+	}
+
+	if createOptions.Location == "" {
+		errorMessages = append(errorMessages, fmt.Sprintf(errorTemplate, "Location"))
+	}
+
+	if len(errorMessages) > 0 {
+		err = errors.New(strings.Join(errorMessages, "\n"))
+	}
+
+	return err
+}
+
+func (slnadcs *softLayer_Network_Application_Delivery_Controller_Service) findVPXByOrderId(orderId int) (datatypes.SoftLayer_Network_Application_Delivery_Controller, error) {
+	ObjectFilter := string(`{"applicationDeliveryControllers":{"billingItem":{"orderItem":{"order":{"id":{"operation":` + strconv.Itoa(orderId) + `}}}}}}`)
+
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"pending"},
+		Target:  []string{"complete"},
+		Refresh: func() (interface{}, string, error) {
+			accountService, err := slnadcs.client.GetSoftLayer_Account_Service()
+			if err != nil {
+				return datatypes.SoftLayer_Network_Application_Delivery_Controller{}, "", err
+			}
+			vpxs, err := accountService.GetApplicationDeliveryControllersWithFilter(ObjectFilter)
+			if err != nil {
+				return datatypes.SoftLayer_Network_Application_Delivery_Controller{}, "", err
+			}
+
+			if len(vpxs) == 1 {
+				return vpxs[0], "complete", nil
+			} else if len(vpxs) == 0 {
+				return nil, "pending", nil
+			} else {
+				return nil, "", fmt.Errorf("Expected one VPX: %s", err)
+			}
+		},
+		Timeout:    10 * time.Minute,
+		Delay:      5 * time.Second,
+		MinTimeout: 3 * time.Second,
+	}
+
+	pendingResult, err := stateConf.WaitForState()
+
+	if err != nil {
+		return datatypes.SoftLayer_Network_Application_Delivery_Controller{}, err
+	}
+
+	var result, ok = pendingResult.(datatypes.SoftLayer_Network_Application_Delivery_Controller)
+
+	if ok {
+		return result, nil
+	}
+
+	return datatypes.SoftLayer_Network_Application_Delivery_Controller{},
+		fmt.Errorf("Cannot find Application Delivery Controller with order id '%d'", orderId)
+}
+
+func (slnadcs *softLayer_Network_Application_Delivery_Controller_Service) getApplicationDeliveryControllerItems() ([]datatypes.SoftLayer_Product_Item, error) {
+	productPackageService, err := slnadcs.client.GetSoftLayer_Product_Package_Service()
+	if err != nil {
+		return []datatypes.SoftLayer_Product_Item{}, err
+	}
+
+	return productPackageService.GetItemsByType(PACKAGE_TYPE_APPLICATION_DELIVERY_CONTROLLER)
+}
+
+func (slnadcs *softLayer_Network_Application_Delivery_Controller_Service) getVPXPriceItemKeyName(version string, speed int, plan string) string {
+	name := "CITRIX_NETSCALER_VPX"
+	speedMeasurements := "MBPS"
+	versionReplaced := strings.Replace(version, ".", DELIMITER, -1)
+	speedString := strconv.Itoa(speed) + speedMeasurements
+	return strings.Join([]string{name, versionReplaced, speedString, strings.ToUpper(plan)}, DELIMITER)
+}
+
+func (slnadcs *softLayer_Network_Application_Delivery_Controller_Service) getPublicIpItemKeyName(ipCount int) string {
+	name := "STATIC_PUBLIC_IP_ADDRESSES"
+	ipCountString := strconv.Itoa(ipCount)
+
+	return strings.Join([]string{ipCountString, name}, DELIMITER)
+}

--- a/vendor/github.com/TheWeatherCompany/softlayer-go/services/softlayer_network_storage.go
+++ b/vendor/github.com/TheWeatherCompany/softlayer-go/services/softlayer_network_storage.go
@@ -1,0 +1,347 @@
+package services
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"time"
+
+	common "github.com/TheWeatherCompany/softlayer-go/common"
+	datatypes "github.com/TheWeatherCompany/softlayer-go/data_types"
+	softlayer "github.com/TheWeatherCompany/softlayer-go/softlayer"
+)
+
+const (
+	NETWORK_PERFORMANCE_STORAGE_PACKAGE_ID = 222
+	BLOCK_ITEM_PRICE_ID                    = 40678 // file or block item price id
+	CREATE_ISCSI_VOLUME_MAX_RETRY_TIME     = 60
+	CREATE_ISCSI_VOLUME_CHECK_INTERVAL     = 5 // seconds
+)
+
+type softLayer_Network_Storage_Service struct {
+	client softlayer.Client
+}
+
+func NewSoftLayer_Network_Storage_Service(client softlayer.Client) *softLayer_Network_Storage_Service {
+	return &softLayer_Network_Storage_Service{
+		client: client,
+	}
+}
+
+func (slns *softLayer_Network_Storage_Service) GetName() string {
+	return "SoftLayer_Network_Storage"
+}
+
+func (slns *softLayer_Network_Storage_Service) CreateIscsiVolume(size int, location string) (datatypes.SoftLayer_Network_Storage, error) {
+	if size < 0 {
+		return datatypes.SoftLayer_Network_Storage{}, errors.New("Cannot create negative sized volumes")
+	}
+
+	sizeItemPriceId, err := slns.getIscsiVolumeItemIdBasedOnSize(size)
+	if err != nil {
+		return datatypes.SoftLayer_Network_Storage{}, err
+	}
+
+	iopsItemPriceId := slns.getPerformanceStorageItemPriceIdByIops(size)
+
+	order := datatypes.SoftLayer_Container_Product_Order_Network_PerformanceStorage_Iscsi{
+		Location:    location,
+		ComplexType: "SoftLayer_Container_Product_Order_Network_PerformanceStorage_Iscsi",
+		OsFormatType: datatypes.SoftLayer_Network_Storage_Iscsi_OS_Type{
+			Id:      12,
+			KeyName: "LINUX",
+		},
+		Prices: []datatypes.SoftLayer_Product_Item_Price{
+			datatypes.SoftLayer_Product_Item_Price{
+				Id: sizeItemPriceId,
+			},
+			datatypes.SoftLayer_Product_Item_Price{
+				Id: iopsItemPriceId,
+			},
+			datatypes.SoftLayer_Product_Item_Price{
+				Id: BLOCK_ITEM_PRICE_ID,
+			},
+		},
+		PackageId: NETWORK_PERFORMANCE_STORAGE_PACKAGE_ID,
+		Quantity:  1,
+	}
+
+	productOrderService, err := slns.client.GetSoftLayer_Product_Order_Service()
+	if err != nil {
+		return datatypes.SoftLayer_Network_Storage{}, err
+	}
+
+	receipt, err := productOrderService.PlaceContainerOrderNetworkPerformanceStorageIscsi(order)
+	if err != nil {
+		return datatypes.SoftLayer_Network_Storage{}, err
+	}
+
+	var iscsiStorage datatypes.SoftLayer_Network_Storage
+
+	for i := 0; i < CREATE_ISCSI_VOLUME_MAX_RETRY_TIME; i++ {
+		iscsiStorage, err = slns.findIscsiVolumeId(receipt.OrderId)
+		if err == nil {
+			break
+		} else if i == CREATE_ISCSI_VOLUME_MAX_RETRY_TIME-1 {
+			return datatypes.SoftLayer_Network_Storage{}, err
+		}
+
+		time.Sleep(CREATE_ISCSI_VOLUME_CHECK_INTERVAL * time.Second)
+	}
+
+	return iscsiStorage, nil
+}
+
+func (slvgs *softLayer_Network_Storage_Service) DeleteObject(volumeId int) (bool, error) {
+	response, errorCode, err := slvgs.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d.json", slvgs.GetName(), volumeId), "DELETE", new(bytes.Buffer))
+
+	if err != nil {
+		return false, err
+	}
+
+	if res := string(response[:]); res != "true" {
+		return false, errors.New(fmt.Sprintf("Failed to delete volume with id '%d', got '%s' as response from the API.", volumeId, res))
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Network_Storage#deleteObject, HTTP error code: '%d'", errorCode)
+		return false, errors.New(errorMessage)
+	}
+
+	return true, err
+}
+
+func (slns *softLayer_Network_Storage_Service) DeleteIscsiVolume(volumeId int, immediateCancellationFlag bool) error {
+
+	billingItem, err := slns.GetBillingItem(volumeId)
+	if err != nil {
+		return err
+	}
+
+	if billingItem.Id > 0 {
+		billingItemService, err := slns.client.GetSoftLayer_Billing_Item_Service()
+		if err != nil {
+			return err
+		}
+
+		deleted, err := billingItemService.CancelService(billingItem.Id)
+		if err != nil {
+			return err
+		}
+
+		if deleted {
+			return nil
+		}
+	}
+
+	errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Network_Storage_Service#deleteIscsiVolume with id: '%d'", volumeId)
+
+	return errors.New(errorMessage)
+}
+
+func (slns *softLayer_Network_Storage_Service) GetIscsiVolume(volumeId int) (datatypes.SoftLayer_Network_Storage, error) {
+	objectMask := []string{
+		"accountId",
+		"capacityGb",
+		"createDate",
+		"guestId",
+		"hardwareId",
+		"hostId",
+		"id",
+		"nasType",
+		"notes",
+		"Password",
+		"serviceProviderId",
+		"upgradableFlag",
+		"username",
+		"billingItem.id",
+		"billingItem.orderItem.order.id",
+		"lunId",
+		"serviceResourceBackendIpAddress",
+	}
+
+	response, errorCode, err := slns.client.GetHttpClient().DoRawHttpRequestWithObjectMask(fmt.Sprintf("%s/%d/getObject.json", slns.GetName(), volumeId), objectMask, "GET", new(bytes.Buffer))
+
+	if err != nil {
+		return datatypes.SoftLayer_Network_Storage{}, err
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Account#getAccountStatus, HTTP error code: '%d'", errorCode)
+		return datatypes.SoftLayer_Network_Storage{}, errors.New(errorMessage)
+	}
+
+	volume := datatypes.SoftLayer_Network_Storage{}
+	err = json.Unmarshal(response, &volume)
+	if err != nil {
+		return datatypes.SoftLayer_Network_Storage{}, err
+	}
+
+	return volume, nil
+}
+
+func (slns *softLayer_Network_Storage_Service) GetBillingItem(volumeId int) (datatypes.SoftLayer_Billing_Item, error) {
+
+	response, errorCode, err := slns.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/getBillingItem.json", slns.GetName(), volumeId), "GET", new(bytes.Buffer))
+	if err != nil {
+		return datatypes.SoftLayer_Billing_Item{}, err
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_NetWork_Storage#getBillingItem, HTTP error code: '%d'", errorCode)
+		return datatypes.SoftLayer_Billing_Item{}, errors.New(errorMessage)
+	}
+
+	billingItem := datatypes.SoftLayer_Billing_Item{}
+	err = json.Unmarshal(response, &billingItem)
+	if err != nil {
+		return datatypes.SoftLayer_Billing_Item{}, err
+	}
+
+	return billingItem, nil
+}
+
+func (slns *softLayer_Network_Storage_Service) HasAllowedVirtualGuest(volumeId int, vmId int) (bool, error) {
+	filter := string(`{"allowedVirtualGuests":{"id":{"operation":"` + strconv.Itoa(vmId) + `"}}}`)
+	response, errorCode, err := slns.client.GetHttpClient().DoRawHttpRequestWithObjectFilterAndObjectMask(fmt.Sprintf("%s/%d/getAllowedVirtualGuests.json", slns.GetName(), volumeId), []string{"id"}, fmt.Sprintf(string(filter)), "GET", new(bytes.Buffer))
+
+	if err != nil {
+		return false, errors.New(fmt.Sprintf("Cannot check authentication for volume %d in vm %d", volumeId, vmId))
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Network_Storage#hasAllowedVirtualGuest, HTTP error code: '%d'", errorCode)
+		return false, errors.New(errorMessage)
+	}
+
+	virtualGuest := []datatypes.SoftLayer_Virtual_Guest{}
+	err = json.Unmarshal(response, &virtualGuest)
+	if err != nil {
+		return false, errors.New(fmt.Sprintf("Failed to unmarshal response of checking authentication for volume %d in vm %d", volumeId, vmId))
+	}
+
+	if len(virtualGuest) > 0 {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+func (slns *softLayer_Network_Storage_Service) AttachIscsiVolume(virtualGuest datatypes.SoftLayer_Virtual_Guest, volumeId int) (bool, error) {
+	parameters := datatypes.SoftLayer_Virtual_Guest_Parameters{
+		Parameters: []datatypes.SoftLayer_Virtual_Guest{
+			virtualGuest,
+		},
+	}
+	requestBody, err := json.Marshal(parameters)
+	if err != nil {
+		return false, err
+	}
+
+	resp, errorCode, err := slns.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/allowAccessFromVirtualGuest.json", slns.GetName(), volumeId), "PUT", bytes.NewBuffer(requestBody))
+
+	if err != nil {
+		return false, err
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Network_Storage#attachIscsiVolume, HTTP error code: '%d'", errorCode)
+		return false, errors.New(errorMessage)
+	}
+
+	allowable, err := strconv.ParseBool(string(resp[:]))
+	if err != nil {
+		return false, nil
+	}
+
+	return allowable, nil
+}
+
+func (slns *softLayer_Network_Storage_Service) DetachIscsiVolume(virtualGuest datatypes.SoftLayer_Virtual_Guest, volumeId int) error {
+	parameters := datatypes.SoftLayer_Virtual_Guest_Parameters{
+		Parameters: []datatypes.SoftLayer_Virtual_Guest{
+			virtualGuest,
+		},
+	}
+	requestBody, err := json.Marshal(parameters)
+	if err != nil {
+		return err
+	}
+
+	_, errorCode, err := slns.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/removeAccessFromVirtualGuest.json", slns.GetName(), volumeId), "PUT", bytes.NewBuffer(requestBody))
+	if err != nil {
+		return err
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Account#getAccountStatus, HTTP error code: '%d'", errorCode)
+		return errors.New(errorMessage)
+	}
+
+	return nil
+}
+
+// Private methods
+
+func (slns *softLayer_Network_Storage_Service) findIscsiVolumeId(orderId int) (datatypes.SoftLayer_Network_Storage, error) {
+	ObjectFilter := string(`{"iscsiNetworkStorage":{"billingItem":{"orderItem":{"order":{"id":{"operation":` + strconv.Itoa(orderId) + `}}}}}}`)
+
+	accountService, err := slns.client.GetSoftLayer_Account_Service()
+	if err != nil {
+		return datatypes.SoftLayer_Network_Storage{}, err
+	}
+
+	iscsiStorages, err := accountService.GetIscsiNetworkStorageWithFilter(ObjectFilter)
+	if err != nil {
+		return datatypes.SoftLayer_Network_Storage{}, err
+	}
+
+	if len(iscsiStorages) == 1 {
+		return iscsiStorages[0], nil
+	}
+
+	return datatypes.SoftLayer_Network_Storage{}, errors.New(fmt.Sprintf("Cannot find an performance storage (iSCSI volume) with order id %d", orderId))
+}
+
+func (slns *softLayer_Network_Storage_Service) getIscsiVolumeItemIdBasedOnSize(size int) (int, error) {
+	productPackageService, err := slns.client.GetSoftLayer_Product_Package_Service()
+	if err != nil {
+		return 0, err
+	}
+
+	itemPrices, err := productPackageService.GetItemPricesBySize(NETWORK_PERFORMANCE_STORAGE_PACKAGE_ID, size)
+	if err != nil {
+		return 0, err
+	}
+
+	var currentItemId int
+
+	if len(itemPrices) > 0 {
+		for _, itemPrice := range itemPrices {
+			if itemPrice.LocationGroupId == 0 {
+				currentItemId = itemPrice.Id
+			}
+		}
+	}
+
+	if currentItemId == 0 {
+		return 0, errors.New(fmt.Sprintf("No proper performance storage (iSCSI volume)for size %d", size))
+	}
+
+	return currentItemId, nil
+}
+
+func (slns *softLayer_Network_Storage_Service) getPerformanceStorageItemPriceIdByIops(size int) int {
+	switch size {
+	case 20:
+		return 40838 // 500 IOPS
+	case 40:
+		return 40988 // 1000 IOPS
+	case 80:
+		return 41288 // 2000 IOPS
+	default:
+		return 41788 // 3000 IOPS
+	}
+}

--- a/vendor/github.com/TheWeatherCompany/softlayer-go/services/softlayer_network_storage_allowed_host.go
+++ b/vendor/github.com/TheWeatherCompany/softlayer-go/services/softlayer_network_storage_allowed_host.go
@@ -1,0 +1,46 @@
+package services
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	common "github.com/TheWeatherCompany/softlayer-go/common"
+	datatypes "github.com/TheWeatherCompany/softlayer-go/data_types"
+	softlayer "github.com/TheWeatherCompany/softlayer-go/softlayer"
+)
+
+type softLayer_Network_Storage_Allowed_Host_Service struct {
+	client softlayer.Client
+}
+
+func NewSoftLayer_Network_Storage_Allowed_Host_Service(client softlayer.Client) *softLayer_Network_Storage_Allowed_Host_Service {
+	return &softLayer_Network_Storage_Allowed_Host_Service{
+		client: client,
+	}
+}
+
+func (slns *softLayer_Network_Storage_Allowed_Host_Service) GetName() string {
+	return "SoftLayer_Network_Storage_Allowed_Host"
+}
+
+func (slns *softLayer_Network_Storage_Allowed_Host_Service) GetCredential(allowedHostId int) (datatypes.SoftLayer_Network_Storage_Credential, error) {
+	response, errorCode, err := slns.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/getCredential.json", slns.GetName(), allowedHostId), "GET", new(bytes.Buffer))
+	if err != nil {
+		return datatypes.SoftLayer_Network_Storage_Credential{}, err
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Network_Storage_Allowed_Host#getCredential, HTTP error code: '%d'", errorCode)
+		return datatypes.SoftLayer_Network_Storage_Credential{}, errors.New(errorMessage)
+	}
+
+	credential := datatypes.SoftLayer_Network_Storage_Credential{}
+	err = json.Unmarshal(response, &credential)
+	if err != nil {
+		return datatypes.SoftLayer_Network_Storage_Credential{}, err
+	}
+
+	return credential, nil
+}

--- a/vendor/github.com/TheWeatherCompany/softlayer-go/services/softlayer_product_order.go
+++ b/vendor/github.com/TheWeatherCompany/softlayer-go/services/softlayer_product_order.go
@@ -1,0 +1,134 @@
+package services
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	common "github.com/TheWeatherCompany/softlayer-go/common"
+	datatypes "github.com/TheWeatherCompany/softlayer-go/data_types"
+	softlayer "github.com/TheWeatherCompany/softlayer-go/softlayer"
+)
+
+type softLayer_Product_Order_Service struct {
+	client softlayer.Client
+}
+
+func NewSoftLayer_Product_Order_Service(client softlayer.Client) *softLayer_Product_Order_Service {
+	return &softLayer_Product_Order_Service{
+		client: client,
+	}
+}
+
+func (slpo *softLayer_Product_Order_Service) GetName() string {
+	return "SoftLayer_Product_Order"
+}
+
+func (slpo *softLayer_Product_Order_Service) PlaceOrder(order datatypes.SoftLayer_Container_Product_Order) (datatypes.SoftLayer_Container_Product_Order_Receipt, error) {
+	parameters := datatypes.SoftLayer_Container_Product_Order_Parameters{
+		Parameters: []datatypes.SoftLayer_Container_Product_Order{
+			order,
+		},
+	}
+
+	requestBody, err := json.Marshal(parameters)
+	if err != nil {
+		return datatypes.SoftLayer_Container_Product_Order_Receipt{}, err
+	}
+
+	responseBytes, errorCode, err := slpo.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/placeOrder.json", slpo.GetName()), "POST", bytes.NewBuffer(requestBody))
+	if err != nil {
+		return datatypes.SoftLayer_Container_Product_Order_Receipt{}, err
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Account#getAccountStatus, HTTP error code: '%d'", errorCode)
+		return datatypes.SoftLayer_Container_Product_Order_Receipt{}, errors.New(errorMessage)
+	}
+
+	receipt := datatypes.SoftLayer_Container_Product_Order_Receipt{}
+	err = json.Unmarshal(responseBytes, &receipt)
+	if err != nil {
+		return datatypes.SoftLayer_Container_Product_Order_Receipt{}, err
+	}
+
+	return receipt, nil
+}
+
+func (slpo *softLayer_Product_Order_Service) PlaceContainerOrderNetworkPerformanceStorageIscsi(order datatypes.SoftLayer_Container_Product_Order_Network_PerformanceStorage_Iscsi) (datatypes.SoftLayer_Container_Product_Order_Receipt, error) {
+	parameters := datatypes.SoftLayer_Container_Product_Order_Network_PerformanceStorage_Iscsi_Parameters{
+		Parameters: []datatypes.SoftLayer_Container_Product_Order_Network_PerformanceStorage_Iscsi{
+			order,
+		},
+	}
+
+	requestBody, err := json.Marshal(parameters)
+	if err != nil {
+		return datatypes.SoftLayer_Container_Product_Order_Receipt{}, err
+	}
+
+	responseBytes, errorCode, err := slpo.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/placeOrder.json", slpo.GetName()), "POST", bytes.NewBuffer(requestBody))
+	if err != nil {
+		return datatypes.SoftLayer_Container_Product_Order_Receipt{}, err
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Product_Order#placeContainerOrderNetworkPerformanceStorageIscsi, HTTP error code: '%d'", errorCode)
+		return datatypes.SoftLayer_Container_Product_Order_Receipt{}, errors.New(errorMessage)
+	}
+
+	receipt := datatypes.SoftLayer_Container_Product_Order_Receipt{}
+	err = json.Unmarshal(responseBytes, &receipt)
+	if err != nil {
+		return datatypes.SoftLayer_Container_Product_Order_Receipt{}, err
+	}
+
+	return receipt, nil
+}
+
+func (slpo *softLayer_Product_Order_Service) PlaceContainerOrderVirtualGuestUpgrade(order datatypes.SoftLayer_Container_Product_Order_Virtual_Guest_Upgrade) (datatypes.SoftLayer_Container_Product_Order_Receipt, error) {
+	parameters := datatypes.SoftLayer_Container_Product_Order_Virtual_Guest_Upgrade_Parameters{
+		Parameters: []datatypes.SoftLayer_Container_Product_Order_Virtual_Guest_Upgrade{
+			order,
+		},
+	}
+	return slpo.placeOrder(parameters)
+}
+
+func (slpo *softLayer_Product_Order_Service) PlaceContainerOrderApplicationDeliveryController(order datatypes.SoftLayer_Container_Product_Order_Network_Application_Delivery_Controller) (datatypes.SoftLayer_Container_Product_Order_Receipt, error) {
+	parameters := datatypes.SoftLayer_Container_Product_Order_Network_Application_Delivery_Controller_Parameters{
+		Parameters: []datatypes.SoftLayer_Container_Product_Order_Network_Application_Delivery_Controller{
+			order,
+		},
+	}
+	return slpo.placeOrder(parameters)
+}
+
+// Private methods
+
+func (slpo *softLayer_Product_Order_Service) placeOrder(parameters interface{}) (datatypes.SoftLayer_Container_Product_Order_Receipt, error) {
+	requestBody, err := json.Marshal(parameters)
+	if err != nil {
+		return datatypes.SoftLayer_Container_Product_Order_Receipt{}, err
+	}
+
+	responseBytes, errorCode, err := slpo.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/placeOrder.json", slpo.GetName()), "POST", bytes.NewBuffer(requestBody))
+	if err != nil {
+		return datatypes.SoftLayer_Container_Product_Order_Receipt{}, err
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Product_Order#placeOrder, HTTP error code: '%d'", errorCode)
+		return datatypes.SoftLayer_Container_Product_Order_Receipt{}, errors.New(errorMessage)
+	}
+
+	receipt := datatypes.SoftLayer_Container_Product_Order_Receipt{}
+
+	err = json.Unmarshal(responseBytes, &receipt)
+	if err != nil {
+		return datatypes.SoftLayer_Container_Product_Order_Receipt{}, err
+	}
+
+	return receipt, nil
+}

--- a/vendor/github.com/TheWeatherCompany/softlayer-go/services/softlayer_product_package.go
+++ b/vendor/github.com/TheWeatherCompany/softlayer-go/services/softlayer_product_package.go
@@ -1,0 +1,176 @@
+package services
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	common "github.com/TheWeatherCompany/softlayer-go/common"
+	datatypes "github.com/TheWeatherCompany/softlayer-go/data_types"
+	softlayer "github.com/TheWeatherCompany/softlayer-go/softlayer"
+)
+
+const (
+	OUTLET_PACKAGE = "OUTLET"
+)
+
+type softLayer_Product_Package_Service struct {
+	client softlayer.Client
+}
+
+func NewSoftLayer_Product_Package_Service(client softlayer.Client) *softLayer_Product_Package_Service {
+	return &softLayer_Product_Package_Service{
+		client: client,
+	}
+}
+
+func (slpp *softLayer_Product_Package_Service) GetName() string {
+	return "SoftLayer_Product_Package"
+}
+
+func (slpp *softLayer_Product_Package_Service) GetItemPrices(packageId int) ([]datatypes.SoftLayer_Product_Item_Price, error) {
+	response, errorCode, err := slpp.client.GetHttpClient().DoRawHttpRequestWithObjectMask(fmt.Sprintf("%s/%d/getItemPrices.json", slpp.GetName(), packageId), []string{"id", "item.id", "item.description", "item.capacity"}, "GET", new(bytes.Buffer))
+	if err != nil {
+		return []datatypes.SoftLayer_Product_Item_Price{}, err
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Product_Package#getItemPrices, HTTP error code: '%d'", errorCode)
+		return []datatypes.SoftLayer_Product_Item_Price{}, errors.New(errorMessage)
+	}
+
+	itemPrices := []datatypes.SoftLayer_Product_Item_Price{}
+	err = json.Unmarshal(response, &itemPrices)
+	if err != nil {
+		return []datatypes.SoftLayer_Product_Item_Price{}, err
+	}
+
+	return itemPrices, nil
+}
+
+func (slpp *softLayer_Product_Package_Service) GetItemPricesBySize(packageId int, size int) ([]datatypes.SoftLayer_Product_Item_Price, error) {
+	keyName := strconv.Itoa(size) + "_GB_PERFORMANCE_STORAGE_SPACE"
+	filter := string(`{"itemPrices":{"item":{"keyName":{"operation":"` + keyName + `"}}}}`)
+
+	response, errorCode, err := slpp.client.GetHttpClient().DoRawHttpRequestWithObjectFilterAndObjectMask(fmt.Sprintf("%s/%d/getItemPrices.json", slpp.GetName(), packageId), []string{"id", "locationGroupId", "item.id", "item.keyName", "item.units", "item.description", "item.capacity"}, fmt.Sprintf(string(filter)), "GET", new(bytes.Buffer))
+	if err != nil {
+		return []datatypes.SoftLayer_Product_Item_Price{}, err
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Product_Package#getItemsPricesBySize, HTTP error code: '%d'", errorCode)
+		return []datatypes.SoftLayer_Product_Item_Price{}, errors.New(errorMessage)
+	}
+
+	itemPrices := []datatypes.SoftLayer_Product_Item_Price{}
+	err = json.Unmarshal(response, &itemPrices)
+	if err != nil {
+		return []datatypes.SoftLayer_Product_Item_Price{}, err
+	}
+
+	return itemPrices, nil
+}
+
+func (slpp *softLayer_Product_Package_Service) GetItemsByType(packageType string) ([]datatypes.SoftLayer_Product_Item, error) {
+	productPackage, err := slpp.GetOnePackageByType(packageType)
+	if err != nil {
+		return []datatypes.SoftLayer_Product_Item{}, err
+	}
+
+	return slpp.GetItems(productPackage.Id)
+}
+
+func (slpp *softLayer_Product_Package_Service) GetItems(packageId int) ([]datatypes.SoftLayer_Product_Item, error) {
+	objectMasks := []string{
+		"id",
+		"capacity",
+		"description",
+		"units",
+		"keyName",
+		"prices.id",
+		"prices.categories.id",
+		"prices.categories.name",
+	}
+
+	response, errorCode, err := slpp.client.GetHttpClient().DoRawHttpRequestWithObjectMask(fmt.Sprintf("%s/%d/getItems.json", slpp.GetName(), packageId), objectMasks, "GET", new(bytes.Buffer))
+	if err != nil {
+		return []datatypes.SoftLayer_Product_Item{}, err
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Product_Package#getItems, HTTP error code: '%d'", errorCode)
+		return []datatypes.SoftLayer_Product_Item{}, errors.New(errorMessage)
+	}
+
+	productItems := []datatypes.SoftLayer_Product_Item{}
+	err = json.Unmarshal(response, &productItems)
+	if err != nil {
+		return []datatypes.SoftLayer_Product_Item{}, err
+	}
+
+	return productItems, nil
+}
+
+func (slpp *softLayer_Product_Package_Service) GetOnePackageByType(packageType string) (datatypes.Softlayer_Product_Package, error) {
+	productPackages, err := slpp.GetPackagesByType(packageType)
+	if err != nil {
+		return datatypes.Softlayer_Product_Package{}, err
+	}
+
+	if len(productPackages) == 0 {
+		return datatypes.Softlayer_Product_Package{}, errors.New(fmt.Sprintf("No packages available for type '%s'.", packageType))
+	}
+
+	return productPackages[0], nil
+}
+
+func (slpp *softLayer_Product_Package_Service) GetPackagesByType(packageType string) ([]datatypes.Softlayer_Product_Package, error) {
+	objectMasks := []string{
+		"id",
+		"name",
+		"description",
+		"isActive",
+		"type.keyName",
+	}
+
+	filterObject := string(`{"type":{"keyName":{"operation":"` + packageType + `"}}}`)
+
+	response, errorCode, err := slpp.client.GetHttpClient().DoRawHttpRequestWithObjectFilterAndObjectMask(fmt.Sprintf("%s/getAllObjects.json", slpp.GetName()), objectMasks, filterObject, "GET", new(bytes.Buffer))
+	if err != nil {
+		return []datatypes.Softlayer_Product_Package{}, err
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Product_Package#getPackagesByType, HTTP error code: '%d'", errorCode)
+		return []datatypes.Softlayer_Product_Package{}, errors.New(errorMessage)
+	}
+
+	productPackages := []*datatypes.Softlayer_Product_Package{}
+	err = json.Unmarshal(response, &productPackages)
+	if err != nil {
+		return []datatypes.Softlayer_Product_Package{}, err
+	}
+
+	// Remove packages designated as OUTLET
+	// See method "#get_packages_of_type" in SoftLayer Python client for details: https://github.com/softlayer/softlayer-python/blob/master/SoftLayer/managers/ordering.py
+	nonOutletPackages := slpp.filterProducts(productPackages, func(productPackage *datatypes.Softlayer_Product_Package) bool {
+		return !strings.Contains(productPackage.Description, OUTLET_PACKAGE) && !strings.Contains(productPackage.Name, OUTLET_PACKAGE)
+	})
+
+	return nonOutletPackages, nil
+}
+
+//Private methods
+
+func (slpp *softLayer_Product_Package_Service) filterProducts(array []*datatypes.Softlayer_Product_Package, predicate func(*datatypes.Softlayer_Product_Package) bool) []datatypes.Softlayer_Product_Package {
+	filtered := make([]datatypes.Softlayer_Product_Package, 0)
+	for _, element := range array {
+		if predicate(element) {
+			filtered = append(filtered, *element)
+		}
+	}
+	return filtered
+}

--- a/vendor/github.com/TheWeatherCompany/softlayer-go/services/softlayer_security_certificate.go
+++ b/vendor/github.com/TheWeatherCompany/softlayer-go/services/softlayer_security_certificate.go
@@ -1,0 +1,99 @@
+package services
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"github.com/TheWeatherCompany/softlayer-go/common"
+	datatypes "github.com/TheWeatherCompany/softlayer-go/data_types"
+	softlayer "github.com/TheWeatherCompany/softlayer-go/softlayer"
+)
+
+type softLayer_Security_Certificate_Service struct {
+	client softlayer.Client
+}
+
+func NewSoftLayer_Security_Certificate_Service(client softlayer.Client) *softLayer_Security_Certificate_Service {
+	return &softLayer_Security_Certificate_Service{
+		client: client,
+	}
+}
+
+func (slscs *softLayer_Security_Certificate_Service) GetName() string {
+	return "SoftLayer_Security_Certificate"
+}
+
+func (slscs *softLayer_Security_Certificate_Service) CreateSecurityCertificate(template datatypes.SoftLayer_Security_Certificate_Template) (datatypes.SoftLayer_Security_Certificate, error) {
+	parameters := datatypes.SoftLayer_Security_Certificate_Parameters{
+		Parameters: []datatypes.SoftLayer_Security_Certificate_Template{{
+			Certificate:             template.Certificate,
+			IntermediateCertificate: template.IntermediateCertificate,
+			PrivateKey:              template.PrivateKey,
+		}},
+	}
+
+	requestBody, err := json.Marshal(parameters)
+	if err != nil {
+		return datatypes.SoftLayer_Security_Certificate{}, fmt.Errorf("Unable to create JSON: %s", err)
+	}
+
+	response, errorCode, err := slscs.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/createObject.json", slscs.GetName()), "POST", bytes.NewBuffer(requestBody))
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not create SoftLayer_Security_Certificate, HTTP error code: '%d'", errorCode)
+		return datatypes.SoftLayer_Security_Certificate{}, errors.New(errorMessage)
+	}
+
+	if err != nil {
+		return datatypes.SoftLayer_Security_Certificate{}, err
+	}
+
+	securityCertificate := datatypes.SoftLayer_Security_Certificate{}
+	err = json.Unmarshal(response, &securityCertificate)
+	if err != nil {
+		return datatypes.SoftLayer_Security_Certificate{}, err
+	}
+
+	return securityCertificate, nil
+}
+
+func (slscs *softLayer_Security_Certificate_Service) GetObject(id int) (datatypes.SoftLayer_Security_Certificate, error) {
+	response, errorCode, err := slscs.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/getObject.json", slscs.GetName(), id), "GET", new(bytes.Buffer))
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not retrieve SoftLayer_Security_Certificate, HTTP error code: '%d'", errorCode)
+		return datatypes.SoftLayer_Security_Certificate{}, errors.New(errorMessage)
+	}
+
+	if err != nil {
+		return datatypes.SoftLayer_Security_Certificate{}, err
+	}
+
+	securityCertificate := datatypes.SoftLayer_Security_Certificate{}
+	err = json.Unmarshal(response, &securityCertificate)
+	if err != nil {
+		return datatypes.SoftLayer_Security_Certificate{}, err
+	}
+
+	return securityCertificate, nil
+}
+
+func (slscs *softLayer_Security_Certificate_Service) DeleteObject(id int) (bool, error) {
+	response, errorCode, err := slscs.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d.json", slscs.GetName(), id), "DELETE", new(bytes.Buffer))
+
+	if res := string(response[:]); res != "true" {
+		return false, errors.New(fmt.Sprintf("Failed to delete Security Certificate with id '%d', got '%s' as response from the API.", id, res))
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not delete SoftLayer_Security_Certificate, HTTP error code: '%d'", errorCode)
+		return false, errors.New(errorMessage)
+	}
+
+	if err != nil {
+		return false, err
+	}
+
+	return true, nil
+}

--- a/vendor/github.com/TheWeatherCompany/softlayer-go/services/softlayer_security_ssh_key.go
+++ b/vendor/github.com/TheWeatherCompany/softlayer-go/services/softlayer_security_ssh_key.go
@@ -1,0 +1,159 @@
+package services
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	common "github.com/TheWeatherCompany/softlayer-go/common"
+	datatypes "github.com/TheWeatherCompany/softlayer-go/data_types"
+	softlayer "github.com/TheWeatherCompany/softlayer-go/softlayer"
+)
+
+type softLayer_Security_Ssh_Key_Service struct {
+	client softlayer.Client
+}
+
+func NewSoftLayer_Security_Ssh_Key_Service(client softlayer.Client) *softLayer_Security_Ssh_Key_Service {
+	return &softLayer_Security_Ssh_Key_Service{
+		client: client,
+	}
+}
+
+func (slssks *softLayer_Security_Ssh_Key_Service) GetName() string {
+	return "SoftLayer_Security_Ssh_Key"
+}
+
+func (slssks *softLayer_Security_Ssh_Key_Service) CreateObject(template datatypes.SoftLayer_Security_Ssh_Key) (datatypes.SoftLayer_Security_Ssh_Key, error) {
+	parameters := datatypes.SoftLayer_Shh_Key_Parameters{
+		Parameters: []datatypes.SoftLayer_Security_Ssh_Key{
+			template,
+		},
+	}
+
+	requestBody, err := json.Marshal(parameters)
+	if err != nil {
+		return datatypes.SoftLayer_Security_Ssh_Key{}, err
+	}
+
+	data, errorCode, err := slssks.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/createObject", slssks.GetName()), "POST", bytes.NewBuffer(requestBody))
+	if err != nil {
+		return datatypes.SoftLayer_Security_Ssh_Key{}, err
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Security_Ssh_Key#createObject, HTTP error code: '%d'", errorCode)
+		return datatypes.SoftLayer_Security_Ssh_Key{}, errors.New(errorMessage)
+	}
+
+	err = slssks.client.GetHttpClient().CheckForHttpResponseErrors(data)
+	if err != nil {
+		return datatypes.SoftLayer_Security_Ssh_Key{}, err
+	}
+
+	softLayer_Ssh_Key := datatypes.SoftLayer_Security_Ssh_Key{}
+	err = json.Unmarshal(data, &softLayer_Ssh_Key)
+	if err != nil {
+		return datatypes.SoftLayer_Security_Ssh_Key{}, err
+	}
+
+	return softLayer_Ssh_Key, nil
+}
+
+func (slssks *softLayer_Security_Ssh_Key_Service) GetObject(sshKeyId int) (datatypes.SoftLayer_Security_Ssh_Key, error) {
+	objectMask := []string{
+		"createDate",
+		"fingerprint",
+		"id",
+		"key",
+		"label",
+		"modifyDate",
+		"notes",
+	}
+
+	response, errorCode, err := slssks.client.GetHttpClient().DoRawHttpRequestWithObjectMask(fmt.Sprintf("%s/%d/getObject.json", slssks.GetName(), sshKeyId), objectMask, "GET", new(bytes.Buffer))
+	if err != nil {
+		return datatypes.SoftLayer_Security_Ssh_Key{}, err
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Security_Ssh_Key#getObject, HTTP error code: '%d'", errorCode)
+		return datatypes.SoftLayer_Security_Ssh_Key{}, errors.New(errorMessage)
+	}
+
+	sshKey := datatypes.SoftLayer_Security_Ssh_Key{}
+	err = json.Unmarshal(response, &sshKey)
+	if err != nil {
+		return datatypes.SoftLayer_Security_Ssh_Key{}, err
+	}
+
+	return sshKey, nil
+}
+
+func (slssks *softLayer_Security_Ssh_Key_Service) EditObject(sshKeyId int, template datatypes.SoftLayer_Security_Ssh_Key) (bool, error) {
+	parameters := datatypes.SoftLayer_Shh_Key_Parameters{
+		Parameters: []datatypes.SoftLayer_Security_Ssh_Key{
+			template,
+		},
+	}
+
+	requestBody, err := json.Marshal(parameters)
+	if err != nil {
+		return false, err
+	}
+
+	response, errorCode, err := slssks.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/editObject.json", slssks.GetName(), sshKeyId), "POST", bytes.NewBuffer(requestBody))
+	if err != nil {
+		return false, err
+	}
+
+	if res := string(response[:]); res != "true" {
+		return false, errors.New(fmt.Sprintf("Failed to edit SSH key with id: %d, got '%s' as response from the API.", sshKeyId, res))
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Security_Ssh_Key#editObject, HTTP error code: '%d'", errorCode)
+		return false, errors.New(errorMessage)
+	}
+
+	return true, err
+}
+
+func (slssks *softLayer_Security_Ssh_Key_Service) DeleteObject(sshKeyId int) (bool, error) {
+	response, errorCode, err := slssks.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d.json", slssks.GetName(), sshKeyId), "DELETE", new(bytes.Buffer))
+	if err != nil {
+		return false, err
+	}
+
+	if res := string(response[:]); res != "true" {
+		return false, errors.New(fmt.Sprintf("Failed to destroy ssh key with id '%d', got '%s' as response from the API.", sshKeyId, res))
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Security_Ssh_Key#deleteObject, HTTP error code: '%d'", errorCode)
+		return false, errors.New(errorMessage)
+	}
+
+	return true, err
+}
+
+func (slssks *softLayer_Security_Ssh_Key_Service) GetSoftwarePasswords(sshKeyId int) ([]datatypes.SoftLayer_Software_Component_Password, error) {
+	response, errorCode, err := slssks.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/getSoftwarePasswords.json", slssks.GetName(), sshKeyId), "GET", new(bytes.Buffer))
+	if err != nil {
+		return []datatypes.SoftLayer_Software_Component_Password{}, err
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Security_Ssh_Key#getSoftwarePasswords, HTTP error code: '%d'", errorCode)
+		return []datatypes.SoftLayer_Software_Component_Password{}, errors.New(errorMessage)
+	}
+
+	passwords := []datatypes.SoftLayer_Software_Component_Password{}
+	err = json.Unmarshal(response, &passwords)
+	if err != nil {
+		return []datatypes.SoftLayer_Software_Component_Password{}, err
+	}
+
+	return passwords, nil
+}

--- a/vendor/github.com/TheWeatherCompany/softlayer-go/services/softlayer_user_customer.go
+++ b/vendor/github.com/TheWeatherCompany/softlayer-go/services/softlayer_user_customer.go
@@ -1,0 +1,355 @@
+package services
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"github.com/TheWeatherCompany/softlayer-go/common"
+	"github.com/TheWeatherCompany/softlayer-go/data_types"
+	"github.com/TheWeatherCompany/softlayer-go/softlayer"
+)
+
+type softlayer_user_customer_service struct {
+	client softlayer.Client
+}
+
+func NewSoftLayer_User_Customer_Service(client softlayer.Client) *softlayer_user_customer_service {
+	return &softlayer_user_customer_service{
+		client: client,
+	}
+}
+
+func (slucs *softlayer_user_customer_service) GetName() string {
+	return "SoftLayer_User_Customer"
+}
+
+func (slucs *softlayer_user_customer_service) CreateObject(template data_types.SoftLayer_User_Customer, password string) (data_types.SoftLayer_User_Customer, error) {
+	parameters := data_types.SoftLayer_User_Customer_Parameters{
+		Parameters: []interface{}{
+			template,
+			password,
+		},
+	}
+
+	requestBody, err := json.Marshal(parameters)
+	if err != nil {
+		return data_types.SoftLayer_User_Customer{}, err
+	}
+
+	data, errorCode, err := slucs.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/createObject", slucs.GetName()), "POST", bytes.NewBuffer(requestBody))
+	if err != nil {
+		return data_types.SoftLayer_User_Customer{}, err
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_User_Customer#createObject\nResponse from SoftLayer: %s\nHTTP error code: '%d'", data, errorCode)
+		return data_types.SoftLayer_User_Customer{}, errors.New(errorMessage)
+	}
+
+	err = slucs.client.GetHttpClient().CheckForHttpResponseErrors(data)
+	if err != nil {
+		return data_types.SoftLayer_User_Customer{}, err
+	}
+
+	softLayer_User_Customer := data_types.SoftLayer_User_Customer{}
+	err = json.Unmarshal(data, &softLayer_User_Customer)
+	if err != nil {
+		return data_types.SoftLayer_User_Customer{}, err
+	}
+
+	return softLayer_User_Customer, nil
+}
+
+/*
+ * https://api.softlayer.com/rest/v3/SoftLayer_User_Customer/630887.json?objectMask=id;username;\
+       firstname;lastname;email;companyName;address1;address2;city;state;country;timezoneId;\
+       userStatusId;displayName;parentId;permissions;apiAuthenticationKeys
+*/
+func (slucs *softlayer_user_customer_service) GetObject(userid int) (data_types.SoftLayer_User_Customer, error) {
+	objectMask := []string{
+		"id",
+		"username",
+		"firstName",
+		"lastName",
+		"email",
+		"companyName",
+		"address1",
+		"address2",
+		"city",
+		"state",
+		"country",
+		"timezoneId",
+		"userStatusId",
+		"displayName",
+		"parentId",
+		"permissions",
+		"apiAuthenticationKeys",
+	}
+
+	response, errorCode, err := slucs.client.GetHttpClient().DoRawHttpRequestWithObjectMask(fmt.Sprintf("%s/%d/getObject.json", slucs.GetName(), userid), objectMask, "GET", new(bytes.Buffer))
+	if err != nil {
+		return data_types.SoftLayer_User_Customer{}, err
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_User_Customer#getObject, HTTP error code: '%d'", errorCode)
+		return data_types.SoftLayer_User_Customer{}, errors.New(errorMessage)
+	}
+
+	user := data_types.SoftLayer_User_Customer{}
+	err = json.Unmarshal(response, &user)
+	if err != nil {
+		return data_types.SoftLayer_User_Customer{}, err
+	}
+
+	return user, nil
+}
+
+func (slucs *softlayer_user_customer_service) EditObject(userid int, template data_types.SoftLayer_User_Customer) (bool, error) {
+	parameters := data_types.SoftLayer_User_Customer_Parameters{
+		Parameters: []interface{}{
+			template,
+		},
+	}
+
+	requestBody, err := json.Marshal(parameters)
+	if err != nil {
+		return false, err
+	}
+
+	response, errorCode, err := slucs.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/editObject.json", slucs.GetName(), userid), "POST", bytes.NewBuffer(requestBody))
+	if err != nil {
+		return false, err
+	}
+
+	if res := string(response[:]); res != "true" {
+		return false, errors.New(fmt.Sprintf("Failed to edit SoftLayer user with id: %d, got '%s' as response from the API.", userid, res))
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_User_Customer#editObject, HTTP error code: '%d'", errorCode)
+		return false, errors.New(errorMessage)
+	}
+
+	return true, err
+}
+
+func (slucs *softlayer_user_customer_service) DeleteObject(userid int) (bool, error) {
+	deleteForm := data_types.SoftLayer_User_Customer_Delete{
+		UserStatus: 1021,
+	}
+	parameters := data_types.SoftLayer_User_Customer_Parameters{
+		Parameters: []interface{}{
+			deleteForm,
+		},
+	}
+
+	requestBody, err := json.Marshal(parameters)
+	if err != nil {
+		return false, err
+	}
+
+	response, errorCode, err := slucs.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/editObject.json", slucs.GetName(), userid), "POST", bytes.NewBuffer(requestBody))
+	if err != nil {
+		return false, err
+	}
+
+	if res := string(response[:]); res != "true" {
+		return false, errors.New(fmt.Sprintf("Failed to destroy SoftLayer user with id '%d', got '%s' as response from the API.", userid, res))
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_User_Customer#deleteObject, HTTP error code: '%d'", errorCode)
+		return false, errors.New(errorMessage)
+	}
+
+	return true, err
+}
+
+/*
+ * https://api.softlayer.com/rest/v3/SoftLayer_User_Customer/630887/getApiAuthenticationKeys.json
+ */
+func (slucs *softlayer_user_customer_service) GetApiAuthenticationKeys(userId int) ([]data_types.SoftLayer_User_Customer_ApiAuthentication, error) {
+	path := fmt.Sprintf("%s/%d/%s.json", slucs.GetName(), userId, "getApiAuthenticationKeys")
+	responseBytes, errorCode, err := slucs.client.GetHttpClient().DoRawHttpRequest(path, "GET", &bytes.Buffer{})
+	if err != nil {
+		errorMessage := fmt.Sprintf(
+			"softlayer-go: could not %s#getApiAuthenticationKeys, error message '%s'",
+			slucs.GetName(), err.Error(),
+		)
+		return nil, errors.New(errorMessage)
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf(
+			"softlayer-go: could not %s#getApiAuthenticationKeys, HTTP error code: '%d'",
+			slucs.GetName(), errorCode,
+		)
+		return nil, errors.New(errorMessage)
+	}
+
+	apiKeys := []data_types.SoftLayer_User_Customer_ApiAuthentication{}
+	err = json.Unmarshal(responseBytes, &apiKeys)
+	if err != nil {
+		errorMessage := fmt.Sprintf(
+			"softlayer-go: failed to decode JSON response from %s#getApiAuthenticationKeys, err message '%s'",
+			slucs.GetName(), err.Error(),
+		)
+		err := errors.New(errorMessage)
+		return nil, err
+	}
+
+	return apiKeys, nil
+}
+
+/*
+ * https://api.softlayer.com/rest/v3/SoftLayer_User_Customer/630887/addApiAuthenticationKey.json
+ */
+func (slucs *softlayer_user_customer_service) AddApiAuthenticationKey(userId int) error {
+	path := fmt.Sprintf("%s/%d/%s.json", slucs.GetName(), userId, "addApiAuthenticationKey")
+	_, errorCode, err := slucs.client.GetHttpClient().DoRawHttpRequest(path, "GET", &bytes.Buffer{})
+	if err != nil {
+		errorMessage := fmt.Sprintf(
+			"softlayer-go: could not %s#addApiAuthenticationKey, error message '%s'",
+			slucs.GetName(), err.Error(),
+		)
+		return errors.New(errorMessage)
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf(
+			"softlayer-go: could not %s#addApiAuthenticationKey, HTTP error code: '%d'",
+			slucs.GetName(), errorCode,
+		)
+		return errors.New(errorMessage)
+	}
+
+	return nil
+}
+
+/*
+ * https://api.softlayer.com/rest/v3/SoftLayer_User_Customer/630887/removeApiAuthenticationKey/871423.json
+ */
+func (slucs *softlayer_user_customer_service) RemoveApiAuthenticationKey(userId int, apiKeys []data_types.SoftLayer_User_Customer_ApiAuthentication) (bool, error) {
+	// Even though a whole api auth key structure is passed as input parameter, one softlayer user login can only have one api auth key.
+	// Extract the api auth key id.
+	apiAuthKeyId := apiKeys[0].Id
+	path := fmt.Sprintf("%s/%d/%s/%d.json", slucs.GetName(), userId, "removeApiAuthenticationKey", apiAuthKeyId)
+	response, errorCode, err := slucs.client.GetHttpClient().DoRawHttpRequest(path, "GET", &bytes.Buffer{})
+	if err != nil {
+		errorMessage := fmt.Sprintf("softlayer-go: could not %s, error message: '%s'", path, err.Error())
+		return false, errors.New(errorMessage)
+	}
+
+	if res := string(response[:]); res != "true" {
+		errorMessage := fmt.Sprintf("softlayer-go: could not %s. Response received: '%s'", path, res)
+		return false, errors.New(errorMessage)
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not %s. HTTP error code: '%d'", path, errorCode)
+		return false, errors.New(errorMessage)
+	}
+
+	return true, nil
+}
+
+func (slucs *softlayer_user_customer_service) AddBulkPortalPermission(userId int, permissions []data_types.SoftLayer_User_Customer_CustomerPermission_Permission) error {
+	parameters := data_types.SoftLayer_User_Customer_Parameters{
+		Parameters: []interface{}{
+			permissions,
+		},
+	}
+
+	requestBody, err := json.Marshal(parameters)
+	if err != nil {
+		return nil
+	}
+
+	path := fmt.Sprintf("%s/%d/%s", slucs.GetName(), userId, "addBulkPortalPermission.json")
+	_, errorCode, err := slucs.client.GetHttpClient().DoRawHttpRequest(path, "PUT", bytes.NewBuffer(requestBody))
+	if err != nil {
+		errorMessage := fmt.Sprintf(
+			"softlayer-go: could not %s#addBulkPortalPermission, error message '%s'",
+			slucs.GetName(), err.Error(),
+		)
+		return errors.New(errorMessage)
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf(
+			"softlayer-go: could not %s#addBulkPortalPermission, HTTP error code: '%d'",
+			slucs.GetName(), errorCode,
+		)
+		return errors.New(errorMessage)
+	}
+
+	return nil
+}
+
+func (slucs *softlayer_user_customer_service) RemoveBulkPortalPermission(userId int, permissions []data_types.SoftLayer_User_Customer_CustomerPermission_Permission) error {
+	parameters := data_types.SoftLayer_User_Customer_Parameters{
+		Parameters: []interface{}{
+			permissions,
+		},
+	}
+
+	requestBody, err := json.Marshal(parameters)
+	if err != nil {
+		return nil
+	}
+
+	path := fmt.Sprintf("%s/%d/%s", slucs.GetName(), userId, "removeBulkPortalPermission.json")
+	_, errorCode, err := slucs.client.GetHttpClient().DoRawHttpRequest(path, "PUT", bytes.NewBuffer(requestBody))
+	if err != nil {
+		errorMessage := fmt.Sprintf(
+			"softlayer-go: could not %s#removeBulkPortalPermission, error message '%s'",
+			slucs.GetName(), err.Error(),
+		)
+		return errors.New(errorMessage)
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf(
+			"softlayer-go: could not %s#removeBulkPortalPermission, HTTP error code: '%d'",
+			slucs.GetName(), errorCode,
+		)
+		return errors.New(errorMessage)
+	}
+
+	return nil
+}
+
+func (slucs *softlayer_user_customer_service) GetPermissions(userId int) ([]data_types.SoftLayer_User_Customer_CustomerPermission_Permission, error) {
+	path := fmt.Sprintf("%s/%d/%s", slucs.GetName(), userId, "getPermissions.json")
+	responseBytes, errorCode, err := slucs.client.GetHttpClient().DoRawHttpRequest(path, "GET", &bytes.Buffer{})
+	if err != nil {
+		errorMessage := fmt.Sprintf(
+			"softlayer-go: could not %s#getPermissions, error message '%s'",
+			slucs.GetName(), err.Error(),
+		)
+		return nil, errors.New(errorMessage)
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf(
+			"softlayer-go: could not %s#getPermissions, HTTP error code: '%d'",
+			slucs.GetName(), errorCode,
+		)
+		return nil, errors.New(errorMessage)
+	}
+
+	permissions := []data_types.SoftLayer_User_Customer_CustomerPermission_Permission{}
+	err = json.Unmarshal(responseBytes, &permissions)
+	if err != nil {
+		errorMessage := fmt.Sprintf(
+			"softlayer-go: failed to decode JSON response from %s#getPermissions, err message '%s'",
+			slucs.GetName(), err.Error(),
+		)
+		err := errors.New(errorMessage)
+		return nil, err
+	}
+
+	return permissions, nil
+}

--- a/vendor/github.com/TheWeatherCompany/softlayer-go/services/softlayer_virtual_disk_image.go
+++ b/vendor/github.com/TheWeatherCompany/softlayer-go/services/softlayer_virtual_disk_image.go
@@ -1,0 +1,46 @@
+package services
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	common "github.com/TheWeatherCompany/softlayer-go/common"
+	datatypes "github.com/TheWeatherCompany/softlayer-go/data_types"
+	softlayer "github.com/TheWeatherCompany/softlayer-go/softlayer"
+)
+
+type softLayer_Virtual_Disk_Image_Service struct {
+	client softlayer.Client
+}
+
+func NewSoftLayer_Virtual_Disk_Image_Service(client softlayer.Client) *softLayer_Virtual_Disk_Image_Service {
+	return &softLayer_Virtual_Disk_Image_Service{
+		client: client,
+	}
+}
+
+func (slvdi *softLayer_Virtual_Disk_Image_Service) GetName() string {
+	return "SoftLayer_Virtual_Disk_Image"
+}
+
+func (slvdi *softLayer_Virtual_Disk_Image_Service) GetObject(vdImageId int) (datatypes.SoftLayer_Virtual_Disk_Image, error) {
+	response, errorCode, err := slvdi.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/getObject.json", slvdi.GetName(), vdImageId), "GET", new(bytes.Buffer))
+	if err != nil {
+		return datatypes.SoftLayer_Virtual_Disk_Image{}, err
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Virtual_Disk_Image#getObject, HTTP error code: '%d'", errorCode)
+		return datatypes.SoftLayer_Virtual_Disk_Image{}, errors.New(errorMessage)
+	}
+
+	vdImage := datatypes.SoftLayer_Virtual_Disk_Image{}
+	err = json.Unmarshal(response, &vdImage)
+	if err != nil {
+		return datatypes.SoftLayer_Virtual_Disk_Image{}, err
+	}
+
+	return vdImage, nil
+}

--- a/vendor/github.com/TheWeatherCompany/softlayer-go/services/softlayer_virtual_guest.go
+++ b/vendor/github.com/TheWeatherCompany/softlayer-go/services/softlayer_virtual_guest.go
@@ -1,0 +1,1233 @@
+package services
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	common "github.com/TheWeatherCompany/softlayer-go/common"
+	datatypes "github.com/TheWeatherCompany/softlayer-go/data_types"
+	softlayer "github.com/TheWeatherCompany/softlayer-go/softlayer"
+)
+
+const (
+	EPHEMERAL_DISK_CATEGORY_CODE = "guest_disk1"
+	// Package type for virtual servers: http://sldn.softlayer.com/reference/services/SoftLayer_Product_Order/placeOrder
+	VIRTUAL_SERVER_PACKAGE_TYPE = "VIRTUAL_SERVER_INSTANCE"
+	MAINTENANCE_WINDOW_PROPERTY = "MAINTENANCE_WINDOW"
+	// Described in the following link: http://sldn.softlayer.com/reference/datatypes/SoftLayer_Container_Product_Order_Virtual_Guest_Upgrade
+	UPGRADE_VIRTUAL_SERVER_ORDER_TYPE = "SoftLayer_Container_Product_Order_Virtual_Guest_Upgrade"
+)
+
+type softLayer_Virtual_Guest_Service struct {
+	client softlayer.Client
+}
+
+func NewSoftLayer_Virtual_Guest_Service(client softlayer.Client) *softLayer_Virtual_Guest_Service {
+	return &softLayer_Virtual_Guest_Service{
+		client: client,
+	}
+}
+
+func (slvgs *softLayer_Virtual_Guest_Service) GetName() string {
+	return "SoftLayer_Virtual_Guest"
+}
+
+func (slvgs *softLayer_Virtual_Guest_Service) CreateObject(template datatypes.SoftLayer_Virtual_Guest_Template) (datatypes.SoftLayer_Virtual_Guest, error) {
+	err := slvgs.checkCreateObjectRequiredValues(template)
+	if err != nil {
+		return datatypes.SoftLayer_Virtual_Guest{}, err
+	}
+
+	parameters := datatypes.SoftLayer_Virtual_Guest_Template_Parameters{
+		Parameters: []datatypes.SoftLayer_Virtual_Guest_Template{
+			template,
+		},
+	}
+
+	requestBody, err := json.Marshal(parameters)
+	if err != nil {
+		return datatypes.SoftLayer_Virtual_Guest{}, err
+	}
+
+	response, errorCode, err := slvgs.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s.json", slvgs.GetName()), "POST", bytes.NewBuffer(requestBody))
+	if err != nil {
+		return datatypes.SoftLayer_Virtual_Guest{}, err
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Virtual_Guest#createObject, HTTP error code: '%d'", errorCode)
+		return datatypes.SoftLayer_Virtual_Guest{}, errors.New(errorMessage)
+	}
+
+	err = slvgs.client.GetHttpClient().CheckForHttpResponseErrors(response)
+	if err != nil {
+		return datatypes.SoftLayer_Virtual_Guest{}, err
+	}
+
+	softLayer_Virtual_Guest := datatypes.SoftLayer_Virtual_Guest{}
+	err = json.Unmarshal(response, &softLayer_Virtual_Guest)
+	if err != nil {
+		return datatypes.SoftLayer_Virtual_Guest{}, err
+	}
+
+	return softLayer_Virtual_Guest, nil
+}
+
+func (slvgs *softLayer_Virtual_Guest_Service) ReloadOperatingSystem(instanceId int, template datatypes.Image_Template_Config) error {
+	parameter := [2]interface{}{"FORCE", template}
+	parameters := map[string]interface{}{
+		"parameters": parameter,
+	}
+
+	requestBody, err := json.Marshal(parameters)
+	if err != nil {
+		return err
+	}
+
+	response, errorCode, err := slvgs.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/reloadOperatingSystem.json", slvgs.GetName(), instanceId), "POST", bytes.NewBuffer(requestBody))
+	if err != nil {
+		return err
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Virtual_Guest#reloadOperatingSystem, HTTP error code: '%d'", errorCode)
+		return errors.New(errorMessage)
+	}
+
+	if res := string(response[:]); res != `"1"` {
+		return errors.New(fmt.Sprintf("Failed to reload OS on instance with id '%d', got '%s' as response from the API.", instanceId, res))
+	}
+
+	return nil
+}
+
+func (slvgs *softLayer_Virtual_Guest_Service) GetObject(instanceId int) (datatypes.SoftLayer_Virtual_Guest, error) {
+
+	objectMask := []string{
+		"accountId",
+		"createDate",
+		"dedicatedAccountHostOnlyFlag",
+		"domain",
+		"fullyQualifiedDomainName",
+		"hostname",
+		"hourlyBillingFlag",
+		"id",
+		"lastPowerStateId",
+		"lastVerifiedDate",
+		"maxCpu",
+		"maxCpuUnits",
+		"maxMemory",
+		"metricPollDate",
+		"modifyDate",
+		"notes",
+		"postInstallScriptUri",
+		"privateNetworkOnlyFlag",
+		"startCpus",
+		"statusId",
+		"uuid",
+		"userData.value",
+		"localDiskFlag",
+
+		"globalIdentifier",
+		"managedResourceFlag",
+		"primaryBackendIpAddress",
+		"primaryIpAddress",
+
+		"location.name",
+		"location.longName",
+		"location.id",
+		"datacenter.name",
+		"datacenter.longName",
+		"datacenter.id",
+		"networkComponents.maxSpeed",
+		"operatingSystem.passwords.password",
+		"operatingSystem.passwords.username",
+
+		"blockDeviceTemplateGroup.globalIdentifier",
+		"primaryNetworkComponent.networkVlan.id",
+		"primaryBackendNetworkComponent.networkVlan.id",
+	}
+
+	response, errorCode, err := slvgs.client.GetHttpClient().DoRawHttpRequestWithObjectMask(fmt.Sprintf("%s/%d/getObject.json", slvgs.GetName(), instanceId), objectMask, "GET", new(bytes.Buffer))
+	if err != nil {
+		return datatypes.SoftLayer_Virtual_Guest{}, err
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Virtual_Guest#getObject, HTTP error code: '%d'", errorCode)
+		return datatypes.SoftLayer_Virtual_Guest{}, errors.New(errorMessage)
+	}
+
+	virtualGuest := datatypes.SoftLayer_Virtual_Guest{}
+	err = json.Unmarshal(response, &virtualGuest)
+	if err != nil {
+		return datatypes.SoftLayer_Virtual_Guest{}, err
+	}
+
+	return virtualGuest, nil
+}
+
+func (slvgs *softLayer_Virtual_Guest_Service) GetObjectByPrimaryIpAddress(ipAddress string) (datatypes.SoftLayer_Virtual_Guest, error) {
+
+	ObjectFilter := string(`{"virtualGuests":{"primaryIpAddress":{"operation":"` + ipAddress + `"}}}`)
+
+	accountService, err := slvgs.client.GetSoftLayer_Account_Service()
+	if err != nil {
+		return datatypes.SoftLayer_Virtual_Guest{}, err
+	}
+
+	virtualGuests, err := accountService.GetVirtualGuestsByFilter(ObjectFilter)
+	if err != nil {
+		return datatypes.SoftLayer_Virtual_Guest{}, err
+	}
+
+	if len(virtualGuests) == 1 {
+		return virtualGuests[0], nil
+	}
+
+	return datatypes.SoftLayer_Virtual_Guest{}, errors.New(fmt.Sprintf("Cannot find virtual guest with primary ip: %s", ipAddress))
+}
+
+func (slvgs *softLayer_Virtual_Guest_Service) GetObjectByPrimaryBackendIpAddress(ipAddress string) (datatypes.SoftLayer_Virtual_Guest, error) {
+
+	ObjectFilter := string(`{"virtualGuests":{"primaryBackendIpAddress":{"operation":` + ipAddress + `}}}`)
+
+	accountService, err := slvgs.client.GetSoftLayer_Account_Service()
+	if err != nil {
+		return datatypes.SoftLayer_Virtual_Guest{}, err
+	}
+
+	virtualGuests, err := accountService.GetVirtualGuestsByFilter(ObjectFilter)
+	if err != nil {
+		return datatypes.SoftLayer_Virtual_Guest{}, err
+	}
+
+	if len(virtualGuests) == 1 {
+		return virtualGuests[0], nil
+	}
+
+	return datatypes.SoftLayer_Virtual_Guest{}, errors.New(fmt.Sprintf("Cannot find virtual guest with primary backend ip: %s", ipAddress))
+}
+
+func (slvgs *softLayer_Virtual_Guest_Service) EditObject(instanceId int, template datatypes.SoftLayer_Virtual_Guest) (bool, error) {
+	parameters := datatypes.SoftLayer_Virtual_Guest_Parameters{
+		Parameters: []datatypes.SoftLayer_Virtual_Guest{template},
+	}
+
+	requestBody, err := json.Marshal(parameters)
+	if err != nil {
+		return false, err
+	}
+
+	response, errorCode, err := slvgs.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/editObject.json", slvgs.GetName(), instanceId), "POST", bytes.NewBuffer(requestBody))
+	if err != nil {
+		return false, err
+	}
+
+	if res := string(response[:]); res != "true" {
+		return false, errors.New(fmt.Sprintf("Failed to edit virtual guest with id: %d, got '%s' as response from the API.", instanceId, res))
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Virtual_Guest#editObject, HTTP error code: '%d'", errorCode)
+		return false, errors.New(errorMessage)
+	}
+
+	return true, err
+}
+
+func (slvgs *softLayer_Virtual_Guest_Service) DeleteObject(instanceId int) (bool, error) {
+	response, errorCode, err := slvgs.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d.json", slvgs.GetName(), instanceId), "DELETE", new(bytes.Buffer))
+	if err != nil {
+		return false, err
+	}
+
+	if res := string(response[:]); res != "true" {
+		return false, errors.New(fmt.Sprintf("Failed to delete instance with id '%d', got '%s' as response from the API.", instanceId, res))
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Virtual_Guest#deleteObject, HTTP error code: '%d'", errorCode)
+		return false, errors.New(errorMessage)
+	}
+
+	return true, err
+}
+
+func (slvgs *softLayer_Virtual_Guest_Service) GetPowerState(instanceId int) (datatypes.SoftLayer_Virtual_Guest_Power_State, error) {
+	response, errorCode, err := slvgs.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/getPowerState.json", slvgs.GetName(), instanceId), "GET", new(bytes.Buffer))
+	if err != nil {
+		return datatypes.SoftLayer_Virtual_Guest_Power_State{}, err
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Virtual_Guest#getPowerState, HTTP error code: '%d'", errorCode)
+		return datatypes.SoftLayer_Virtual_Guest_Power_State{}, errors.New(errorMessage)
+	}
+
+	vgPowerState := datatypes.SoftLayer_Virtual_Guest_Power_State{}
+	err = json.Unmarshal(response, &vgPowerState)
+	if err != nil {
+		return datatypes.SoftLayer_Virtual_Guest_Power_State{}, err
+	}
+
+	return vgPowerState, nil
+}
+
+func (slvgs *softLayer_Virtual_Guest_Service) GetPrimaryIpAddress(instanceId int) (string, error) {
+	response, errorCode, err := slvgs.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/getPrimaryIpAddress.json", slvgs.GetName(), instanceId), "GET", new(bytes.Buffer))
+	if err != nil {
+		return "", err
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Virtual_Guest#getPrimaryIpAddress, HTTP error code: '%d'", errorCode)
+		return "", errors.New(errorMessage)
+	}
+
+	vgPrimaryIpAddress := strings.TrimSpace(string(response))
+	if vgPrimaryIpAddress == "" {
+		return "", errors.New(fmt.Sprintf("Failed to get primary IP address for instance with id '%d', got '%s' as response from the API.", instanceId, response))
+	}
+
+	return vgPrimaryIpAddress, nil
+}
+
+func (slvgs *softLayer_Virtual_Guest_Service) GetActiveTransaction(instanceId int) (datatypes.SoftLayer_Provisioning_Version1_Transaction, error) {
+	response, errorCode, err := slvgs.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/getActiveTransaction.json", slvgs.GetName(), instanceId), "GET", new(bytes.Buffer))
+	if err != nil {
+		return datatypes.SoftLayer_Provisioning_Version1_Transaction{}, err
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Virtual_Guest#getActiveTransaction, HTTP error code: '%d'", errorCode)
+		return datatypes.SoftLayer_Provisioning_Version1_Transaction{}, errors.New(errorMessage)
+	}
+
+	activeTransaction := datatypes.SoftLayer_Provisioning_Version1_Transaction{}
+	err = json.Unmarshal(response, &activeTransaction)
+	if err != nil {
+		return datatypes.SoftLayer_Provisioning_Version1_Transaction{}, err
+	}
+
+	return activeTransaction, nil
+}
+
+func (slvgs *softLayer_Virtual_Guest_Service) GetLastTransaction(instanceId int) (datatypes.SoftLayer_Provisioning_Version1_Transaction, error) {
+	objectMask := []string{
+		"transactionGroup",
+	}
+
+	response, errorCode, err := slvgs.client.GetHttpClient().DoRawHttpRequestWithObjectMask(fmt.Sprintf("%s/%d/getLastTransaction.json", slvgs.GetName(), instanceId), objectMask, "GET", new(bytes.Buffer))
+	if err != nil {
+		return datatypes.SoftLayer_Provisioning_Version1_Transaction{}, err
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Virtual_Guest#getLastTransaction, HTTP error code: '%d'", errorCode)
+		return datatypes.SoftLayer_Provisioning_Version1_Transaction{}, errors.New(errorMessage)
+	}
+
+	lastTransaction := datatypes.SoftLayer_Provisioning_Version1_Transaction{}
+	err = json.Unmarshal(response, &lastTransaction)
+	if err != nil {
+		return datatypes.SoftLayer_Provisioning_Version1_Transaction{}, err
+	}
+
+	return lastTransaction, nil
+}
+
+func (slvgs *softLayer_Virtual_Guest_Service) GetActiveTransactions(instanceId int) ([]datatypes.SoftLayer_Provisioning_Version1_Transaction, error) {
+	response, errorCode, err := slvgs.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/getActiveTransactions.json", slvgs.GetName(), instanceId), "GET", new(bytes.Buffer))
+	if err != nil {
+		return []datatypes.SoftLayer_Provisioning_Version1_Transaction{}, err
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Virtual_Guest#getActiveTransactions, HTTP error code: '%d'", errorCode)
+		return []datatypes.SoftLayer_Provisioning_Version1_Transaction{}, errors.New(errorMessage)
+	}
+
+	activeTransactions := []datatypes.SoftLayer_Provisioning_Version1_Transaction{}
+	err = json.Unmarshal(response, &activeTransactions)
+	if err != nil {
+		return []datatypes.SoftLayer_Provisioning_Version1_Transaction{}, err
+	}
+
+	return activeTransactions, nil
+}
+
+func (slvgs *softLayer_Virtual_Guest_Service) GetSshKeys(instanceId int) ([]datatypes.SoftLayer_Security_Ssh_Key, error) {
+	response, errorCode, err := slvgs.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/getSshKeys.json", slvgs.GetName(), instanceId), "GET", new(bytes.Buffer))
+	if err != nil {
+		return []datatypes.SoftLayer_Security_Ssh_Key{}, err
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Virtual_Guest#getSshKeys, HTTP error code: '%d'", errorCode)
+		return []datatypes.SoftLayer_Security_Ssh_Key{}, errors.New(errorMessage)
+	}
+
+	sshKeys := []datatypes.SoftLayer_Security_Ssh_Key{}
+	err = json.Unmarshal(response, &sshKeys)
+	if err != nil {
+		return []datatypes.SoftLayer_Security_Ssh_Key{}, err
+	}
+
+	return sshKeys, nil
+}
+
+func (slvgs *softLayer_Virtual_Guest_Service) PowerCycle(instanceId int) (bool, error) {
+	response, errorCode, err := slvgs.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/powerCycle.json", slvgs.GetName(), instanceId), "GET", new(bytes.Buffer))
+	if err != nil {
+		return false, err
+	}
+
+	if res := string(response[:]); res != "true" {
+		return false, errors.New(fmt.Sprintf("Failed to power cycle instance with id '%d', got '%s' as response from the API.", instanceId, res))
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Virtual_Guest#powerCycle, HTTP error code: '%d'", errorCode)
+		return false, errors.New(errorMessage)
+	}
+
+	return true, err
+}
+
+func (slvgs *softLayer_Virtual_Guest_Service) PowerOff(instanceId int) (bool, error) {
+	response, errorCode, err := slvgs.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/powerOff.json", slvgs.GetName(), instanceId), "GET", new(bytes.Buffer))
+	if err != nil {
+		return false, err
+	}
+
+	if res := string(response[:]); res != "true" {
+		return false, errors.New(fmt.Sprintf("Failed to power off instance with id '%d', got '%s' as response from the API.", instanceId, res))
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Virtual_Guest#powerOff, HTTP error code: '%d'", errorCode)
+		return false, errors.New(errorMessage)
+	}
+
+	return true, err
+}
+
+func (slvgs *softLayer_Virtual_Guest_Service) PowerOffSoft(instanceId int) (bool, error) {
+	response, errorCode, err := slvgs.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/powerOffSoft.json", slvgs.GetName(), instanceId), "GET", new(bytes.Buffer))
+	if err != nil {
+		return false, err
+	}
+
+	if res := string(response[:]); res != "true" {
+		return false, errors.New(fmt.Sprintf("Failed to power off soft instance with id '%d', got '%s' as response from the API.", instanceId, res))
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Virtual_Guest#powerOffSoft, HTTP error code: '%d'", errorCode)
+		return false, errors.New(errorMessage)
+	}
+
+	return true, err
+}
+
+func (slvgs *softLayer_Virtual_Guest_Service) PowerOn(instanceId int) (bool, error) {
+	response, errorCode, err := slvgs.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/powerOn.json", slvgs.GetName(), instanceId), "GET", new(bytes.Buffer))
+	if err != nil {
+		return false, err
+	}
+
+	if res := string(response[:]); res != "true" {
+		return false, errors.New(fmt.Sprintf("Failed to power on instance with id '%d', got '%s' as response from the API.", instanceId, res))
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Virtual_Guest#powerOn, HTTP error code: '%d'", errorCode)
+		return false, errors.New(errorMessage)
+	}
+
+	return true, err
+}
+
+func (slvgs *softLayer_Virtual_Guest_Service) RebootDefault(instanceId int) (bool, error) {
+	response, errorCode, err := slvgs.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/rebootDefault.json", slvgs.GetName(), instanceId), "GET", new(bytes.Buffer))
+	if err != nil {
+		return false, err
+	}
+
+	if res := string(response[:]); res != "true" {
+		return false, errors.New(fmt.Sprintf("Failed to default reboot instance with id '%d', got '%s' as response from the API.", instanceId, res))
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Virtual_Guest#rebootDefault, HTTP error code: '%d'", errorCode)
+		return false, errors.New(errorMessage)
+	}
+
+	return true, err
+}
+
+func (slvgs *softLayer_Virtual_Guest_Service) RebootSoft(instanceId int) (bool, error) {
+	response, errorCode, err := slvgs.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/rebootSoft.json", slvgs.GetName(), instanceId), "GET", new(bytes.Buffer))
+	if err != nil {
+		return false, err
+	}
+
+	if res := string(response[:]); res != "true" {
+		return false, errors.New(fmt.Sprintf("Failed to soft reboot instance with id '%d', got '%s' as response from the API.", instanceId, res))
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Virtual_Guest#rebootSoft, HTTP error code: '%d'", errorCode)
+		return false, errors.New(errorMessage)
+	}
+
+	return true, err
+}
+
+func (slvgs *softLayer_Virtual_Guest_Service) RebootHard(instanceId int) (bool, error) {
+	response, errorCode, err := slvgs.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/rebootHard.json", slvgs.GetName(), instanceId), "GET", new(bytes.Buffer))
+	if err != nil {
+		return false, err
+	}
+
+	if res := string(response[:]); res != "true" {
+		return false, errors.New(fmt.Sprintf("Failed to hard reboot instance with id '%d', got '%s' as response from the API.", instanceId, res))
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Virtual_Guest#rebootHard, HTTP error code: '%d'", errorCode)
+		return false, errors.New(errorMessage)
+	}
+
+	return true, err
+}
+
+func (slvgs *softLayer_Virtual_Guest_Service) SetMetadata(instanceId int, metadata string) (bool, error) {
+	dataBytes := []byte(metadata)
+	base64EncodedMetadata := base64.StdEncoding.EncodeToString(dataBytes)
+
+	parameters := datatypes.SoftLayer_SetUserMetadata_Parameters{
+		Parameters: []datatypes.UserMetadataArray{
+			[]datatypes.UserMetadata{datatypes.UserMetadata(base64EncodedMetadata)},
+		},
+	}
+
+	requestBody, err := json.Marshal(parameters)
+	if err != nil {
+		return false, err
+	}
+
+	response, errorCode, err := slvgs.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/setUserMetadata.json", slvgs.GetName(), instanceId), "POST", bytes.NewBuffer(requestBody))
+	if err != nil {
+		return false, err
+	}
+
+	if res := string(response[:]); res != "true" {
+		return false, errors.New(fmt.Sprintf("Failed to setUserMetadata for instance with id '%d', got '%s' as response from the API.", instanceId, res))
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Virtual_Guest#setUserMetadata, HTTP error code: '%d'", errorCode)
+		return false, errors.New(errorMessage)
+	}
+
+	return true, err
+}
+
+func (slvgs *softLayer_Virtual_Guest_Service) ConfigureMetadataDisk(instanceId int) (datatypes.SoftLayer_Provisioning_Version1_Transaction, error) {
+	response, errorCode, err := slvgs.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/configureMetadataDisk.json", slvgs.GetName(), instanceId), "GET", new(bytes.Buffer))
+	if err != nil {
+		return datatypes.SoftLayer_Provisioning_Version1_Transaction{}, err
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Virtual_Guest#setUserMetadata, HTTP error code: '%d'", errorCode)
+		return datatypes.SoftLayer_Provisioning_Version1_Transaction{}, errors.New(errorMessage)
+	}
+
+	transaction := datatypes.SoftLayer_Provisioning_Version1_Transaction{}
+	err = json.Unmarshal(response, &transaction)
+	if err != nil {
+		return datatypes.SoftLayer_Provisioning_Version1_Transaction{}, err
+	}
+
+	return transaction, nil
+}
+
+func (slvgs *softLayer_Virtual_Guest_Service) GetUserData(instanceId int) ([]datatypes.SoftLayer_Virtual_Guest_Attribute, error) {
+	response, errorCode, err := slvgs.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/getUserData.json", slvgs.GetName(), instanceId), "GET", new(bytes.Buffer))
+	if err != nil {
+		return []datatypes.SoftLayer_Virtual_Guest_Attribute{}, err
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Virtual_Guest#getUserData, HTTP error code: '%d'", errorCode)
+		return []datatypes.SoftLayer_Virtual_Guest_Attribute{}, errors.New(errorMessage)
+	}
+
+	attributes := []datatypes.SoftLayer_Virtual_Guest_Attribute{}
+	err = json.Unmarshal(response, &attributes)
+	if err != nil {
+		return []datatypes.SoftLayer_Virtual_Guest_Attribute{}, err
+	}
+
+	return attributes, nil
+}
+
+func (slvgs *softLayer_Virtual_Guest_Service) IsPingable(instanceId int) (bool, error) {
+	response, errorCode, err := slvgs.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/isPingable.json", slvgs.GetName(), instanceId), "GET", new(bytes.Buffer))
+	if err != nil {
+		return false, err
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Virtual_Guest#isPingable, HTTP error code: '%d'", errorCode)
+		return false, errors.New(errorMessage)
+	}
+
+	res := string(response)
+
+	if res == "true" {
+		return true, nil
+	}
+
+	if res == "false" {
+		return false, nil
+	}
+
+	return false, errors.New(fmt.Sprintf("Failed to checking that virtual guest is pingable for instance with id '%d', got '%s' as response from the API.", instanceId, res))
+}
+
+func (slvgs *softLayer_Virtual_Guest_Service) IsBackendPingable(instanceId int) (bool, error) {
+	response, errorCode, err := slvgs.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/isBackendPingable.json", slvgs.GetName(), instanceId), "GET", new(bytes.Buffer))
+	if err != nil {
+		return false, err
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Virtual_Guest#isBackendPingable, HTTP error code: '%d'", errorCode)
+		return false, errors.New(errorMessage)
+	}
+
+	res := string(response)
+
+	if res == "true" {
+		return true, nil
+	}
+
+	if res == "false" {
+		return false, nil
+	}
+
+	return false, errors.New(fmt.Sprintf("Failed to checking that virtual guest backend is pingable for instance with id '%d', got '%s' as response from the API.", instanceId, res))
+}
+
+func (slvgs *softLayer_Virtual_Guest_Service) AttachEphemeralDisk(instanceId int, diskSize int) (datatypes.SoftLayer_Container_Product_Order_Receipt, error) {
+	diskItemPrice, err := slvgs.findUpgradeItemPriceForEphemeralDisk(instanceId, diskSize)
+	if err != nil {
+		return datatypes.SoftLayer_Container_Product_Order_Receipt{}, err
+	}
+
+	orderService, err := slvgs.client.GetSoftLayer_Product_Order_Service()
+	if err != nil {
+		return datatypes.SoftLayer_Container_Product_Order_Receipt{}, err
+	}
+
+	order := datatypes.SoftLayer_Container_Product_Order_Virtual_Guest_Upgrade{
+		VirtualGuests: []datatypes.VirtualGuest{
+			datatypes.VirtualGuest{
+				Id: instanceId,
+			},
+		},
+		Prices: []datatypes.SoftLayer_Product_Item_Price{
+			datatypes.SoftLayer_Product_Item_Price{
+				Id: diskItemPrice.Id,
+				Categories: []datatypes.Category{
+					datatypes.Category{
+						CategoryCode: EPHEMERAL_DISK_CATEGORY_CODE,
+					},
+				},
+			},
+		},
+		ComplexType: UPGRADE_VIRTUAL_SERVER_ORDER_TYPE,
+		Properties: []datatypes.Property{
+			datatypes.Property{
+				Name:  MAINTENANCE_WINDOW_PROPERTY,
+				Value: time.Now().UTC().Format(time.RFC3339),
+			},
+			datatypes.Property{
+				Name:  "NOTE_GENERAL",
+				Value: "addingdisks",
+			},
+		},
+	}
+
+	receipt, err := orderService.PlaceContainerOrderVirtualGuestUpgrade(order)
+	if err != nil {
+		return datatypes.SoftLayer_Container_Product_Order_Receipt{}, err
+	}
+	return receipt, nil
+}
+
+func (slvgs *softLayer_Virtual_Guest_Service) UpgradeObject(instanceId int, options *softlayer.UpgradeOptions) (bool, error) {
+	prices, err := slvgs.GetAvailableUpgradeItemPrices(options)
+	if err != nil {
+		return false, err
+	}
+
+	if len(prices) == 0 {
+		// Nothing to order, as all the values are up to date
+		return false, nil
+	}
+
+	orderService, err := slvgs.client.GetSoftLayer_Product_Order_Service()
+	if err != nil {
+		return false, err
+	}
+
+	order := datatypes.SoftLayer_Container_Product_Order_Virtual_Guest_Upgrade{
+		VirtualGuests: []datatypes.VirtualGuest{
+			datatypes.VirtualGuest{
+				Id: instanceId,
+			},
+		},
+		Prices:      prices,
+		ComplexType: UPGRADE_VIRTUAL_SERVER_ORDER_TYPE,
+		Properties: []datatypes.Property{
+			datatypes.Property{
+				Name:  MAINTENANCE_WINDOW_PROPERTY,
+				Value: time.Now().UTC().Format(time.RFC3339),
+			},
+		},
+	}
+
+	_, err = orderService.PlaceContainerOrderVirtualGuestUpgrade(order)
+	if err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
+func (slvgs *softLayer_Virtual_Guest_Service) GetAvailableUpgradeItemPrices(upgradeOptions *softlayer.UpgradeOptions) ([]datatypes.SoftLayer_Product_Item_Price, error) {
+	itemsCapacity := make(map[string]int)
+	if upgradeOptions.Cpus > 0 {
+		itemsCapacity["cpus"] = upgradeOptions.Cpus
+	}
+	if upgradeOptions.MemoryInGB > 0 {
+		itemsCapacity["memory"] = upgradeOptions.MemoryInGB
+	}
+	if upgradeOptions.NicSpeed > 0 {
+		itemsCapacity["nic_speed"] = upgradeOptions.NicSpeed
+	}
+
+	virtualServerPackageItems, err := slvgs.getVirtualServerItems()
+	if err != nil {
+		return []datatypes.SoftLayer_Product_Item_Price{}, err
+	}
+
+	prices := make([]datatypes.SoftLayer_Product_Item_Price, 0)
+
+	for item, amount := range itemsCapacity {
+		price, err := slvgs.filterProductItemPrice(virtualServerPackageItems, item, amount)
+		if err != nil {
+			return []datatypes.SoftLayer_Product_Item_Price{}, err
+		}
+
+		prices = append(prices, price)
+	}
+
+	return prices, nil
+}
+
+func (slvgs *softLayer_Virtual_Guest_Service) GetUpgradeItemPrices(instanceId int) ([]datatypes.SoftLayer_Product_Item_Price, error) {
+	response, errorCode, err := slvgs.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/getUpgradeItemPrices.json", slvgs.GetName(), instanceId), "GET", new(bytes.Buffer))
+	if err != nil {
+		return []datatypes.SoftLayer_Product_Item_Price{}, err
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Virtual_Guest#getUpgradeItemPrices, HTTP error code: '%d'", errorCode)
+		return []datatypes.SoftLayer_Product_Item_Price{}, errors.New(errorMessage)
+	}
+
+	itemPrices := []datatypes.SoftLayer_Product_Item_Price{}
+	err = json.Unmarshal(response, &itemPrices)
+	if err != nil {
+		return []datatypes.SoftLayer_Product_Item_Price{}, err
+	}
+
+	return itemPrices, nil
+}
+
+func (slvgs *softLayer_Virtual_Guest_Service) SetTags(instanceId int, tags []string) (bool, error) {
+	var tagStringBuffer bytes.Buffer
+	for i, tag := range tags {
+		tagStringBuffer.WriteString(tag)
+		if i != len(tags)-1 {
+			tagStringBuffer.WriteString(", ")
+		}
+	}
+
+	setTagsParameters := datatypes.SoftLayer_Virtual_Guest_SetTags_Parameters{
+		Parameters: []string{tagStringBuffer.String()},
+	}
+
+	requestBody, err := json.Marshal(setTagsParameters)
+	if err != nil {
+		return false, err
+	}
+
+	response, errorCode, err := slvgs.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/setTags.json", slvgs.GetName(), instanceId), "POST", bytes.NewBuffer(requestBody))
+	if err != nil {
+		return false, err
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Virtual_Guest#setTags, HTTP error code: '%d'", errorCode)
+		return false, errors.New(errorMessage)
+	}
+
+	if res := string(response[:]); res != "true" {
+		return false, errors.New(fmt.Sprintf("Failed to setTags for instance with id '%d', got '%s' as response from the API.", instanceId, res))
+	}
+
+	return true, nil
+}
+
+func (slvgs *softLayer_Virtual_Guest_Service) GetTagReferences(instanceId int) ([]datatypes.SoftLayer_Tag_Reference, error) {
+	response, errorCode, err := slvgs.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/getTagReferences.json", slvgs.GetName(), instanceId), "GET", new(bytes.Buffer))
+	if err != nil {
+		return []datatypes.SoftLayer_Tag_Reference{}, err
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Virtual_Guest#getTagReferences, HTTP error code: '%d'", errorCode)
+		return []datatypes.SoftLayer_Tag_Reference{}, errors.New(errorMessage)
+	}
+
+	tagReferences := []datatypes.SoftLayer_Tag_Reference{}
+	err = json.Unmarshal(response, &tagReferences)
+	if err != nil {
+		return []datatypes.SoftLayer_Tag_Reference{}, err
+	}
+
+	return tagReferences, nil
+}
+
+func (slvgs *softLayer_Virtual_Guest_Service) AttachDiskImage(instanceId int, imageId int) (datatypes.SoftLayer_Provisioning_Version1_Transaction, error) {
+	parameters := datatypes.SoftLayer_Virtual_GuestInit_ImageId_Parameters{
+		Parameters: datatypes.ImageId_Parameter{
+			ImageId: imageId,
+		},
+	}
+
+	requestBody, err := json.Marshal(parameters)
+	if err != nil {
+		return datatypes.SoftLayer_Provisioning_Version1_Transaction{}, err
+	}
+
+	response, errorCode, err := slvgs.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/attachDiskImage.json", slvgs.GetName(), instanceId), "POST", bytes.NewBuffer(requestBody))
+	if err != nil {
+		return datatypes.SoftLayer_Provisioning_Version1_Transaction{}, err
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Virtual_Guest#attachDiskImage, HTTP error code: '%d'", errorCode)
+		return datatypes.SoftLayer_Provisioning_Version1_Transaction{}, errors.New(errorMessage)
+	}
+
+	transaction := datatypes.SoftLayer_Provisioning_Version1_Transaction{}
+	err = json.Unmarshal(response, &transaction)
+	if err != nil {
+		return datatypes.SoftLayer_Provisioning_Version1_Transaction{}, err
+	}
+
+	return transaction, nil
+}
+
+func (slvgs *softLayer_Virtual_Guest_Service) DetachDiskImage(instanceId int, imageId int) (datatypes.SoftLayer_Provisioning_Version1_Transaction, error) {
+	parameters := datatypes.SoftLayer_Virtual_GuestInit_ImageId_Parameters{
+		Parameters: datatypes.ImageId_Parameter{
+			ImageId: imageId,
+		},
+	}
+
+	requestBody, err := json.Marshal(parameters)
+	if err != nil {
+		return datatypes.SoftLayer_Provisioning_Version1_Transaction{}, err
+	}
+
+	response, errorCode, err := slvgs.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/detachDiskImage.json", slvgs.GetName(), instanceId), "POST", bytes.NewBuffer(requestBody))
+	if err != nil {
+		return datatypes.SoftLayer_Provisioning_Version1_Transaction{}, err
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Virtual_Guest#detachDiskImage, HTTP error code: '%d'", errorCode)
+		return datatypes.SoftLayer_Provisioning_Version1_Transaction{}, errors.New(errorMessage)
+	}
+
+	transaction := datatypes.SoftLayer_Provisioning_Version1_Transaction{}
+	err = json.Unmarshal(response, &transaction)
+	if err != nil {
+		return datatypes.SoftLayer_Provisioning_Version1_Transaction{}, err
+	}
+
+	return transaction, nil
+}
+
+func (slvgs *softLayer_Virtual_Guest_Service) ActivatePrivatePort(instanceId int) (bool, error) {
+	response, errorCode, err := slvgs.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/activatePrivatePort.json", slvgs.GetName(), instanceId), "GET", new(bytes.Buffer))
+	if err != nil {
+		return false, err
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Virtual_Guest#activatePrivatePort, HTTP error code: '%d'", errorCode)
+		return false, errors.New(errorMessage)
+	}
+
+	res := string(response)
+
+	if res == "true" {
+		return true, nil
+	}
+
+	if res == "false" {
+		return false, nil
+	}
+
+	return false, errors.New(fmt.Sprintf("Failed to activate private port for virtual guest is pingable for instance with id '%d', got '%s' as response from the API.", instanceId, res))
+}
+
+func (slvgs *softLayer_Virtual_Guest_Service) ActivatePublicPort(instanceId int) (bool, error) {
+	response, errorCode, err := slvgs.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/activatePublicPort.json", slvgs.GetName(), instanceId), "GET", new(bytes.Buffer))
+	if err != nil {
+		return false, err
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Virtual_Guest#activatePublicPort, HTTP error code: '%d'", errorCode)
+		return false, errors.New(errorMessage)
+	}
+
+	res := string(response)
+
+	if res == "true" {
+		return true, nil
+	}
+
+	if res == "false" {
+		return false, nil
+	}
+
+	return false, errors.New(fmt.Sprintf("Failed to activate public port for virtual guest is pingable for instance with id '%d', got '%s' as response from the API.", instanceId, res))
+}
+
+func (slvgs *softLayer_Virtual_Guest_Service) ShutdownPrivatePort(instanceId int) (bool, error) {
+	response, errorCode, err := slvgs.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/shutdownPrivatePort.json", slvgs.GetName(), instanceId), "GET", new(bytes.Buffer))
+	if err != nil {
+		return false, err
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Virtual_Guest#shutdownPrivatePort, HTTP error code: '%d'", errorCode)
+		return false, errors.New(errorMessage)
+	}
+
+	res := string(response)
+
+	if res == "true" {
+		return true, nil
+	}
+
+	if res == "false" {
+		return false, nil
+	}
+
+	return false, errors.New(fmt.Sprintf("Failed to shutdown private port for virtual guest is pingable for instance with id '%d', got '%s' as response from the API.", instanceId, res))
+}
+
+func (slvgs *softLayer_Virtual_Guest_Service) ShutdownPublicPort(instanceId int) (bool, error) {
+	response, errorCode, err := slvgs.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/shutdownPublicPort.json", slvgs.GetName(), instanceId), "GET", new(bytes.Buffer))
+	if err != nil {
+		return false, err
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Virtual_Guest#shutdownPublicPort, HTTP error code: '%d'", errorCode)
+		return false, errors.New(errorMessage)
+	}
+
+	res := string(response)
+
+	if res == "true" {
+		return true, nil
+	}
+
+	if res == "false" {
+		return false, nil
+	}
+
+	return false, errors.New(fmt.Sprintf("Failed to shutdown public port for virtual guest is pingable for instance with id '%d', got '%s' as response from the API.", instanceId, res))
+}
+
+func (slvgs *softLayer_Virtual_Guest_Service) GetAllowedHost(instanceId int) (datatypes.SoftLayer_Network_Storage_Allowed_Host, error) {
+	response, errorCode, err := slvgs.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/getAllowedHost.json", slvgs.GetName(), instanceId), "GET", new(bytes.Buffer))
+	if err != nil {
+		return datatypes.SoftLayer_Network_Storage_Allowed_Host{}, err
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Virtual_Guest#getAllowedHost, HTTP error code: '%d'", errorCode)
+		return datatypes.SoftLayer_Network_Storage_Allowed_Host{}, errors.New(errorMessage)
+	}
+
+	allowedHost := datatypes.SoftLayer_Network_Storage_Allowed_Host{}
+	err = json.Unmarshal(response, &allowedHost)
+	if err != nil {
+		return datatypes.SoftLayer_Network_Storage_Allowed_Host{}, err
+	}
+
+	return allowedHost, nil
+}
+
+func (slvgs *softLayer_Virtual_Guest_Service) GetNetworkVlans(instanceId int) ([]datatypes.SoftLayer_Network_Vlan, error) {
+	response, errorCode, err := slvgs.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/getNetworkVlans.json", slvgs.GetName(), instanceId), "GET", new(bytes.Buffer))
+	if err != nil {
+		return []datatypes.SoftLayer_Network_Vlan{}, err
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Virtual_Guest#getNetworkVlans, HTTP error code: '%d'", errorCode)
+		return []datatypes.SoftLayer_Network_Vlan{}, errors.New(errorMessage)
+	}
+
+	networkVlans := []datatypes.SoftLayer_Network_Vlan{}
+	err = json.Unmarshal(response, &networkVlans)
+	if err != nil {
+		return []datatypes.SoftLayer_Network_Vlan{}, err
+	}
+
+	return networkVlans, nil
+}
+
+func (slvgs *softLayer_Virtual_Guest_Service) CheckHostDiskAvailability(instanceId int, diskCapacity int) (bool, error) {
+	response, errorCode, err := slvgs.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/checkHostDiskAvailability/%d", slvgs.GetName(), instanceId, diskCapacity), "GET", new(bytes.Buffer))
+	if err != nil {
+		return false, err
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Virtual_Guest#checkHostDiskAvailability, HTTP error code: '%d'", errorCode)
+		return false, errors.New(errorMessage)
+	}
+
+	res := string(response)
+
+	if res == "true" {
+		return true, nil
+	}
+
+	if res == "false" {
+		return false, nil
+	}
+
+	return false, errors.New(fmt.Sprintf("Failed to check host disk availability for instance '%d', got '%s' as response from the API.", instanceId, res))
+}
+
+func (slvgs *softLayer_Virtual_Guest_Service) CaptureImage(instanceId int) (datatypes.SoftLayer_Container_Disk_Image_Capture_Template, error) {
+	response, errorCode, err := slvgs.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/captureImage.json", slvgs.GetName(), instanceId), "GET", new(bytes.Buffer))
+	if err != nil {
+		return datatypes.SoftLayer_Container_Disk_Image_Capture_Template{}, err
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Virtual_Guest#captureImage, HTTP error code: '%d'", errorCode)
+		return datatypes.SoftLayer_Container_Disk_Image_Capture_Template{}, errors.New(errorMessage)
+	}
+
+	diskImageTemplate := datatypes.SoftLayer_Container_Disk_Image_Capture_Template{}
+	err = json.Unmarshal(response, &diskImageTemplate)
+	if err != nil {
+		return datatypes.SoftLayer_Container_Disk_Image_Capture_Template{}, err
+	}
+
+	return diskImageTemplate, nil
+}
+
+func (slvgs *softLayer_Virtual_Guest_Service) CreateArchiveTransaction(instanceId int, groupName string, blockDevices []datatypes.SoftLayer_Virtual_Guest_Block_Device, note string) (datatypes.SoftLayer_Provisioning_Version1_Transaction, error) {
+	groupName = url.QueryEscape(groupName)
+	note = url.QueryEscape(note)
+
+	parameters := datatypes.SoftLayer_Virtual_GuestInitParameters{
+		Parameters: []interface{}{groupName, blockDevices, note},
+	}
+
+	requestBody, err := json.Marshal(parameters)
+	if err != nil {
+		return datatypes.SoftLayer_Provisioning_Version1_Transaction{}, err
+	}
+
+	response, errorCode, err := slvgs.client.GetHttpClient().DoRawHttpRequest(fmt.Sprintf("%s/%d/createArchiveTransaction.json", slvgs.GetName(), instanceId), "POST", bytes.NewBuffer(requestBody))
+	if err != nil {
+		return datatypes.SoftLayer_Provisioning_Version1_Transaction{}, err
+	}
+
+	if common.IsHttpErrorCode(errorCode) {
+		errorMessage := fmt.Sprintf("softlayer-go: could not SoftLayer_Virtual_Guest#createArchiveTransaction, HTTP error code: '%d'", errorCode)
+		return datatypes.SoftLayer_Provisioning_Version1_Transaction{}, errors.New(errorMessage)
+	}
+
+	transaction := datatypes.SoftLayer_Provisioning_Version1_Transaction{}
+	err = json.Unmarshal(response, &transaction)
+	if err != nil {
+		return datatypes.SoftLayer_Provisioning_Version1_Transaction{}, err
+	}
+
+	return transaction, nil
+}
+
+//Private methods
+
+func (slvgs *softLayer_Virtual_Guest_Service) getVirtualServerItems() ([]datatypes.SoftLayer_Product_Item, error) {
+	service, err := slvgs.client.GetSoftLayer_Product_Package_Service()
+	if err != nil {
+		return []datatypes.SoftLayer_Product_Item{}, err
+	}
+
+	return service.GetItemsByType(VIRTUAL_SERVER_PACKAGE_TYPE)
+}
+
+func (slvgs *softLayer_Virtual_Guest_Service) filterProductItemPrice(packageItems []datatypes.SoftLayer_Product_Item, option string, amount int) (datatypes.SoftLayer_Product_Item_Price, error) {
+	// for now use hardcoded values in the same "style" as Python client does
+	// refer to corresponding Python method #_get_item_id_for_upgrade: https://github.com/softlayer/softlayer-python/blob/master/SoftLayer/managers/vs.py
+	vsId := map[string]int{
+		"memory":    3,
+		"cpus":      80,
+		"nic_speed": 26,
+	}
+
+	for _, packageItem := range packageItems {
+		categories := packageItem.Prices[0].Categories
+		for _, category := range categories {
+
+			if packageItem.Capacity == "" {
+				continue
+			}
+
+			capacity, err := strconv.Atoi(packageItem.Capacity)
+			if err != nil {
+				return datatypes.SoftLayer_Product_Item_Price{}, err
+			}
+
+			if category.Id != vsId[option] || capacity != amount {
+				continue
+			}
+
+			switch option {
+			case "cpus":
+				if !strings.Contains(packageItem.Description, "Private") {
+					return packageItem.Prices[0], nil
+				}
+			case "nic_speed":
+				if strings.Contains(packageItem.Description, "Public") {
+					return packageItem.Prices[0], nil
+				}
+			default:
+				return packageItem.Prices[0], nil
+			}
+		}
+	}
+
+	return datatypes.SoftLayer_Product_Item_Price{}, errors.New(fmt.Sprintf("Failed to find price for '%s' (of size %d)", option, amount))
+}
+
+func (slvgs *softLayer_Virtual_Guest_Service) checkCreateObjectRequiredValues(template datatypes.SoftLayer_Virtual_Guest_Template) error {
+	var err error
+	errorMessage, errorTemplate := "", "* %s is required and cannot be empty\n"
+
+	if template.Hostname == "" {
+		errorMessage += fmt.Sprintf(errorTemplate, "Hostname for the computing instance")
+	}
+
+	if template.Domain == "" {
+		errorMessage += fmt.Sprintf(errorTemplate, "Domain for the computing instance")
+	}
+
+	if template.StartCpus <= 0 {
+		errorMessage += fmt.Sprintf(errorTemplate, "StartCpus: the number of CPU cores to allocate")
+	}
+
+	if template.MaxMemory <= 0 {
+		errorMessage += fmt.Sprintf(errorTemplate, "MaxMemory: the amount of memory to allocate in megabytes")
+	}
+
+	for _, device := range template.BlockDevices {
+		if device.DiskImage.Capacity <= 0 {
+			errorMessage += fmt.Sprintf("Disk size must be positive number, the size of block device %s is set to be %dGB.", device.Device, device.DiskImage.Capacity)
+		}
+	}
+
+	if template.Datacenter.Name == "" {
+		errorMessage += fmt.Sprintf(errorTemplate, "Datacenter.Name: specifies which datacenter the instance is to be provisioned in")
+	}
+
+	if errorMessage != "" {
+		err = errors.New(errorMessage)
+	}
+
+	return err
+}
+
+func (slvgs *softLayer_Virtual_Guest_Service) findUpgradeItemPriceForEphemeralDisk(instanceId int, ephemeralDiskSize int) (datatypes.SoftLayer_Product_Item_Price, error) {
+	if ephemeralDiskSize <= 0 {
+		return datatypes.SoftLayer_Product_Item_Price{}, errors.New(fmt.Sprintf("Ephemeral disk size can not be negative: %d", ephemeralDiskSize))
+	}
+
+	itemPrices, err := slvgs.GetUpgradeItemPrices(instanceId)
+	if err != nil {
+		return datatypes.SoftLayer_Product_Item_Price{}, nil
+	}
+
+	var currentDiskCapacity int
+	var currentItemPrice datatypes.SoftLayer_Product_Item_Price
+
+	for _, itemPrice := range itemPrices {
+
+		flag := false
+		for _, category := range itemPrice.Categories {
+			if category.CategoryCode == EPHEMERAL_DISK_CATEGORY_CODE {
+				flag = true
+				break
+			}
+		}
+
+		if flag && strings.Contains(itemPrice.Item.Description, "(LOCAL)") {
+
+			capacity, _ := strconv.Atoi(itemPrice.Item.Capacity)
+
+			if capacity >= ephemeralDiskSize {
+				if currentItemPrice.Id == 0 || currentDiskCapacity >= capacity {
+					currentItemPrice = itemPrice
+					currentDiskCapacity = capacity
+				}
+			}
+		}
+	}
+
+	if currentItemPrice.Id == 0 {
+		return datatypes.SoftLayer_Product_Item_Price{}, errors.New(fmt.Sprintf("No proper local disk for size %d", ephemeralDiskSize))
+	}
+
+	return currentItemPrice, nil
+}

--- a/vendor/github.com/TheWeatherCompany/softlayer-go/softlayer/client.go
+++ b/vendor/github.com/TheWeatherCompany/softlayer-go/softlayer/client.go
@@ -1,0 +1,40 @@
+package softlayer
+
+import (
+	"bytes"
+)
+
+type Client interface {
+	GetService(name string) (Service, error)
+
+	GetSoftLayer_Account_Service() (SoftLayer_Account_Service, error)
+	GetSoftLayer_User_Customer_Service() (SoftLayer_User_Customer_Service, error)
+	GetSoftLayer_Virtual_Guest_Service() (SoftLayer_Virtual_Guest_Service, error)
+	GetSoftLayer_Virtual_Disk_Image_Service() (SoftLayer_Virtual_Disk_Image_Service, error)
+	GetSoftLayer_Security_Ssh_Key_Service() (SoftLayer_Security_Ssh_Key_Service, error)
+	GetSoftLayer_Product_Order_Service() (SoftLayer_Product_Order_Service, error)
+	GetSoftLayer_Product_Package_Service() (SoftLayer_Product_Package_Service, error)
+	GetSoftLayer_Network_Storage_Service() (SoftLayer_Network_Storage_Service, error)
+	GetSoftLayer_Network_Storage_Allowed_Host_Service() (SoftLayer_Network_Storage_Allowed_Host_Service, error)
+	GetSoftLayer_Billing_Item_Cancellation_Request_Service() (SoftLayer_Billing_Item_Cancellation_Request_Service, error)
+	GetSoftLayer_Billing_Item_Service() (SoftLayer_Billing_Item_Service, error)
+	GetSoftLayer_Virtual_Guest_Block_Device_Template_Group_Service() (SoftLayer_Virtual_Guest_Block_Device_Template_Group_Service, error)
+	GetSoftLayer_Hardware_Service() (SoftLayer_Hardware_Service, error)
+	GetSoftLayer_Dns_Domain_Service() (SoftLayer_Dns_Domain_Service, error)
+	GetSoftLayer_Network_Application_Delivery_Controller_Service() (SoftLayer_Network_Application_Delivery_Controller_Service, error)
+	GetSoftLayer_Dns_Domain_ResourceRecord_Service() (SoftLayer_Dns_Domain_ResourceRecord_Service, error)
+	GetSoftLayer_Security_Certificate_Service() (SoftLayer_Security_Certificate_Service, error)
+
+	GetHttpClient() HttpClient
+}
+
+type HttpClient interface {
+	DoRawHttpRequest(path string, requestType string, requestBody *bytes.Buffer) ([]byte, int, error)
+	DoRawHttpRequestWithObjectMask(path string, masks []string, requestType string, requestBody *bytes.Buffer) ([]byte, int, error)
+	DoRawHttpRequestWithObjectFilter(path string, filters string, requestType string, requestBody *bytes.Buffer) ([]byte, int, error)
+	DoRawHttpRequestWithObjectFilterAndObjectMask(path string, masks []string, filters string, requestType string, requestBody *bytes.Buffer) ([]byte, int, error)
+	GenerateRequestBody(templateData interface{}) (*bytes.Buffer, error)
+	HasErrors(body map[string]interface{}) error
+
+	CheckForHttpResponseErrors(data []byte) error
+}

--- a/vendor/github.com/TheWeatherCompany/softlayer-go/softlayer/service.go
+++ b/vendor/github.com/TheWeatherCompany/softlayer-go/softlayer/service.go
@@ -1,0 +1,5 @@
+package softlayer
+
+type Service interface {
+	GetName() string
+}

--- a/vendor/github.com/TheWeatherCompany/softlayer-go/softlayer/softlayer_account_service.go
+++ b/vendor/github.com/TheWeatherCompany/softlayer-go/softlayer/softlayer_account_service.go
@@ -1,0 +1,26 @@
+package softlayer
+
+import (
+	datatypes "github.com/TheWeatherCompany/softlayer-go/data_types"
+)
+
+type SoftLayer_Account_Service interface {
+	Service
+
+	GetAccountStatus() (datatypes.SoftLayer_Account_Status, error)
+	GetUsers() ([]datatypes.SoftLayer_User_Customer, error)
+	GetVirtualGuests() ([]datatypes.SoftLayer_Virtual_Guest, error)
+	GetVirtualGuestsByFilter(filters string) ([]datatypes.SoftLayer_Virtual_Guest, error)
+	GetNetworkStorage() ([]datatypes.SoftLayer_Network_Storage, error)
+	GetHubNetworkStorage() ([]datatypes.SoftLayer_Network_Storage, error)
+	GetIscsiNetworkStorage() ([]datatypes.SoftLayer_Network_Storage, error)
+	GetIscsiNetworkStorageWithFilter(filter string) ([]datatypes.SoftLayer_Network_Storage, error)
+	GetVirtualDiskImages() ([]datatypes.SoftLayer_Virtual_Disk_Image, error)
+	GetVirtualDiskImagesWithFilter(filters string) ([]datatypes.SoftLayer_Virtual_Disk_Image, error)
+	GetSshKeys() ([]datatypes.SoftLayer_Security_Ssh_Key, error)
+	GetBlockDeviceTemplateGroups() ([]datatypes.SoftLayer_Virtual_Guest_Block_Device_Template_Group, error)
+	GetBlockDeviceTemplateGroupsWithFilter(filters string) ([]datatypes.SoftLayer_Virtual_Guest_Block_Device_Template_Group, error)
+	GetDatacentersWithSubnetAllocations() ([]datatypes.SoftLayer_Location, error)
+	GetHardware() ([]datatypes.SoftLayer_Hardware, error)
+	GetApplicationDeliveryControllersWithFilter(filter string) ([]datatypes.SoftLayer_Network_Application_Delivery_Controller, error)
+}

--- a/vendor/github.com/TheWeatherCompany/softlayer-go/softlayer/softlayer_billing_item_cancellation_request_service.go
+++ b/vendor/github.com/TheWeatherCompany/softlayer-go/softlayer/softlayer_billing_item_cancellation_request_service.go
@@ -1,0 +1,11 @@
+package softlayer
+
+import (
+	datatypes "github.com/TheWeatherCompany/softlayer-go/data_types"
+)
+
+type SoftLayer_Billing_Item_Cancellation_Request_Service interface {
+	Service
+
+	CreateObject(request datatypes.SoftLayer_Billing_Item_Cancellation_Request) (datatypes.SoftLayer_Billing_Item_Cancellation_Request, error)
+}

--- a/vendor/github.com/TheWeatherCompany/softlayer-go/softlayer/softlayer_billing_item_service.go
+++ b/vendor/github.com/TheWeatherCompany/softlayer-go/softlayer/softlayer_billing_item_service.go
@@ -1,0 +1,7 @@
+package softlayer
+
+type SoftLayer_Billing_Item_Service interface {
+	Service
+
+	CancelService(billingId int) (bool, error)
+}

--- a/vendor/github.com/TheWeatherCompany/softlayer-go/softlayer/softlayer_dns_domain_resource_record_service.go
+++ b/vendor/github.com/TheWeatherCompany/softlayer-go/softlayer/softlayer_dns_domain_resource_record_service.go
@@ -1,0 +1,14 @@
+package softlayer
+
+import (
+	datatypes "github.com/TheWeatherCompany/softlayer-go/data_types"
+)
+
+type SoftLayer_Dns_Domain_ResourceRecord_Service interface {
+	Service
+
+	CreateObject(template datatypes.SoftLayer_Dns_Domain_ResourceRecord_Template) (datatypes.SoftLayer_Dns_Domain_ResourceRecord, error)
+	GetObject(recordId int) (datatypes.SoftLayer_Dns_Domain_ResourceRecord, error)
+	DeleteObject(recordId int) (bool, error)
+	EditObject(recordId int, template datatypes.SoftLayer_Dns_Domain_ResourceRecord) (bool, error)
+}

--- a/vendor/github.com/TheWeatherCompany/softlayer-go/softlayer/softlayer_dns_domain_service.go
+++ b/vendor/github.com/TheWeatherCompany/softlayer-go/softlayer/softlayer_dns_domain_service.go
@@ -1,0 +1,15 @@
+package softlayer
+
+import (
+	datatypes "github.com/TheWeatherCompany/softlayer-go/data_types"
+)
+
+// Modifying existing SoftLayer_Dns_Domain entries is not possible. Changes to zone names should be refactored to creation of new zones.
+// https://sldn.softlayer.com/blog/phil/Getting-started-DNS
+type SoftLayer_Dns_Domain_Service interface {
+	Service
+
+	CreateObject(template datatypes.SoftLayer_Dns_Domain_Template) (datatypes.SoftLayer_Dns_Domain, error)
+	DeleteObject(dnsId int) (bool, error)
+	GetObject(dnsId int) (datatypes.SoftLayer_Dns_Domain, error)
+}

--- a/vendor/github.com/TheWeatherCompany/softlayer-go/softlayer/softlayer_hardware_service.go
+++ b/vendor/github.com/TheWeatherCompany/softlayer-go/softlayer/softlayer_hardware_service.go
@@ -1,0 +1,31 @@
+package softlayer
+
+import (
+	datatypes "github.com/TheWeatherCompany/softlayer-go/data_types"
+)
+
+type SoftLayer_Hardware_Service interface {
+	Service
+
+	AllowAccessToNetworkStorage(id int, storage datatypes.SoftLayer_Network_Storage) (bool, error)
+
+	CreateObject(template datatypes.SoftLayer_Hardware_Template) (datatypes.SoftLayer_Hardware, error)
+
+	FindByIpAddress(ipAddress string) (datatypes.SoftLayer_Hardware, error)
+
+	GetObject(id int) (datatypes.SoftLayer_Hardware, error)
+	GetAllowedHost(id int) (datatypes.SoftLayer_Network_Storage_Allowed_Host, error)
+	GetAttachedNetworkStorages(id int, nasType string) ([]datatypes.SoftLayer_Network_Storage, error)
+	GetDatacenter(id int) (datatypes.SoftLayer_Location, error)
+	GetPrimaryIpAddress(id int) (string, error)
+
+	PowerOff(instanceId int) (bool, error)
+	PowerOffSoft(instanceId int) (bool, error)
+	PowerOn(instanceId int) (bool, error)
+
+	RebootDefault(instanceId int) (bool, error)
+	RebootSoft(instanceId int) (bool, error)
+	RebootHard(instanceId int) (bool, error)
+
+	SetTags(instanceId int, tags []string) (bool, error)
+}

--- a/vendor/github.com/TheWeatherCompany/softlayer-go/softlayer/softlayer_network_application_delivery_controller_service.go
+++ b/vendor/github.com/TheWeatherCompany/softlayer-go/softlayer/softlayer_network_application_delivery_controller_service.go
@@ -1,0 +1,35 @@
+package softlayer
+
+import (
+	datatypes "github.com/TheWeatherCompany/softlayer-go/data_types"
+)
+
+type NetworkApplicationDeliveryControllerCreateOptions struct {
+	Speed    int
+	Version  string
+	Plan     string
+	IpCount  int
+	Location string
+}
+
+type SoftLayer_Network_Application_Delivery_Controller_Service interface {
+	Service
+
+	CreateNetscalerVPX(createOptions *NetworkApplicationDeliveryControllerCreateOptions) (datatypes.SoftLayer_Network_Application_Delivery_Controller, error)
+	CreateVirtualIpAddress(nadcId int, template datatypes.SoftLayer_Network_LoadBalancer_VirtualIpAddress_Template) (bool, error)
+
+	CreateLoadBalancerService(vipId string, nadcId int, template []datatypes.SoftLayer_Network_LoadBalancer_Service_Template) (bool, error)
+
+	DeleteVirtualIpAddress(nadcId int, name string) (bool, error)
+	DeleteObject(id int) (bool, error)
+	DeleteLoadBalancerService(nadcId int, vipId string, serviceId string) (bool, error)
+
+	EditVirtualIpAddress(nadcId int, template datatypes.SoftLayer_Network_LoadBalancer_VirtualIpAddress_Template) (bool, error)
+
+	GetObject(id int) (datatypes.SoftLayer_Network_Application_Delivery_Controller, error)
+	GetBillingItem(id int) (datatypes.SoftLayer_Billing_Item, error)
+	GetVirtualIpAddress(nadcId int, vipName string) (datatypes.SoftLayer_Network_LoadBalancer_VirtualIpAddress, error)
+	GetLoadBalancerService(nadcId int, vipId string, serviceId string) (datatypes.SoftLayer_Network_LoadBalancer_Service, error)
+
+	FindCreatePriceItems(createOptions *NetworkApplicationDeliveryControllerCreateOptions) ([]datatypes.SoftLayer_Product_Item_Price, error)
+}

--- a/vendor/github.com/TheWeatherCompany/softlayer-go/softlayer/softlayer_network_storage_allowed_host_service.go
+++ b/vendor/github.com/TheWeatherCompany/softlayer-go/softlayer/softlayer_network_storage_allowed_host_service.go
@@ -1,0 +1,11 @@
+package softlayer
+
+import (
+	datatypes "github.com/TheWeatherCompany/softlayer-go/data_types"
+)
+
+type SoftLayer_Network_Storage_Allowed_Host_Service interface {
+	Service
+
+	GetCredential(allowedHostId int) (datatypes.SoftLayer_Network_Storage_Credential, error)
+}

--- a/vendor/github.com/TheWeatherCompany/softlayer-go/softlayer/softlayer_network_storage_service.go
+++ b/vendor/github.com/TheWeatherCompany/softlayer-go/softlayer/softlayer_network_storage_service.go
@@ -1,0 +1,19 @@
+package softlayer
+
+import (
+	datatypes "github.com/TheWeatherCompany/softlayer-go/data_types"
+)
+
+type SoftLayer_Network_Storage_Service interface {
+	Service
+
+	DeleteObject(volumeId int) (bool, error)
+
+	CreateIscsiVolume(size int, location string) (datatypes.SoftLayer_Network_Storage, error)
+	DeleteIscsiVolume(volumeId int, immediateCancellationFlag bool) error
+	GetIscsiVolume(volumeId int) (datatypes.SoftLayer_Network_Storage, error)
+	GetBillingItem(volumeId int) (datatypes.SoftLayer_Billing_Item, error)
+	HasAllowedVirtualGuest(volumeId int, vmId int) (bool, error)
+	AttachIscsiVolume(virtualGuest datatypes.SoftLayer_Virtual_Guest, volumeId int) (bool, error)
+	DetachIscsiVolume(virtualGuest datatypes.SoftLayer_Virtual_Guest, volumeId int) error
+}

--- a/vendor/github.com/TheWeatherCompany/softlayer-go/softlayer/softlayer_product_order_service.go
+++ b/vendor/github.com/TheWeatherCompany/softlayer-go/softlayer/softlayer_product_order_service.go
@@ -1,0 +1,14 @@
+package softlayer
+
+import (
+	datatypes "github.com/TheWeatherCompany/softlayer-go/data_types"
+)
+
+type SoftLayer_Product_Order_Service interface {
+	Service
+
+	PlaceOrder(order datatypes.SoftLayer_Container_Product_Order) (datatypes.SoftLayer_Container_Product_Order_Receipt, error)
+	PlaceContainerOrderNetworkPerformanceStorageIscsi(order datatypes.SoftLayer_Container_Product_Order_Network_PerformanceStorage_Iscsi) (datatypes.SoftLayer_Container_Product_Order_Receipt, error)
+	PlaceContainerOrderVirtualGuestUpgrade(order datatypes.SoftLayer_Container_Product_Order_Virtual_Guest_Upgrade) (datatypes.SoftLayer_Container_Product_Order_Receipt, error)
+	PlaceContainerOrderApplicationDeliveryController(order datatypes.SoftLayer_Container_Product_Order_Network_Application_Delivery_Controller) (datatypes.SoftLayer_Container_Product_Order_Receipt, error)
+}

--- a/vendor/github.com/TheWeatherCompany/softlayer-go/softlayer/softlayer_product_package_service.go
+++ b/vendor/github.com/TheWeatherCompany/softlayer-go/softlayer/softlayer_product_package_service.go
@@ -1,0 +1,17 @@
+package softlayer
+
+import (
+	datatypes "github.com/TheWeatherCompany/softlayer-go/data_types"
+)
+
+type SoftLayer_Product_Package_Service interface {
+	Service
+
+	GetItemPrices(packageId int) ([]datatypes.SoftLayer_Product_Item_Price, error)
+	GetItemPricesBySize(packageId int, size int) ([]datatypes.SoftLayer_Product_Item_Price, error)
+	GetItems(packageId int) ([]datatypes.SoftLayer_Product_Item, error)
+	GetItemsByType(packageType string) ([]datatypes.SoftLayer_Product_Item, error)
+
+	GetPackagesByType(packageType string) ([]datatypes.Softlayer_Product_Package, error)
+	GetOnePackageByType(packageType string) (datatypes.Softlayer_Product_Package, error)
+}

--- a/vendor/github.com/TheWeatherCompany/softlayer-go/softlayer/softlayer_security_certificate_service.go
+++ b/vendor/github.com/TheWeatherCompany/softlayer-go/softlayer/softlayer_security_certificate_service.go
@@ -1,0 +1,13 @@
+package softlayer
+
+import (
+	datatypes "github.com/TheWeatherCompany/softlayer-go/data_types"
+)
+
+type SoftLayer_Security_Certificate_Service interface {
+	Service
+
+	CreateSecurityCertificate(template datatypes.SoftLayer_Security_Certificate_Template) (datatypes.SoftLayer_Security_Certificate, error)
+	DeleteObject(id int) (bool, error)
+	GetObject(id int) (datatypes.SoftLayer_Security_Certificate, error)
+}

--- a/vendor/github.com/TheWeatherCompany/softlayer-go/softlayer/softlayer_security_ssh_key_service.go
+++ b/vendor/github.com/TheWeatherCompany/softlayer-go/softlayer/softlayer_security_ssh_key_service.go
@@ -1,0 +1,16 @@
+package softlayer
+
+import (
+	datatypes "github.com/TheWeatherCompany/softlayer-go/data_types"
+)
+
+type SoftLayer_Security_Ssh_Key_Service interface {
+	Service
+
+	CreateObject(template datatypes.SoftLayer_Security_Ssh_Key) (datatypes.SoftLayer_Security_Ssh_Key, error)
+	GetObject(sshkeyId int) (datatypes.SoftLayer_Security_Ssh_Key, error)
+	EditObject(sshkeyId int, template datatypes.SoftLayer_Security_Ssh_Key) (bool, error)
+	DeleteObject(sshKeyId int) (bool, error)
+
+	GetSoftwarePasswords(sshKeyId int) ([]datatypes.SoftLayer_Software_Component_Password, error)
+}

--- a/vendor/github.com/TheWeatherCompany/softlayer-go/softlayer/softlayer_user_customer_service.go
+++ b/vendor/github.com/TheWeatherCompany/softlayer-go/softlayer/softlayer_user_customer_service.go
@@ -1,0 +1,22 @@
+package softlayer
+
+import (
+	"github.com/TheWeatherCompany/softlayer-go/data_types"
+)
+
+type SoftLayer_User_Customer_Service interface {
+	Service
+
+	CreateObject(template data_types.SoftLayer_User_Customer, password string) (data_types.SoftLayer_User_Customer, error)
+	GetObject(userId int) (data_types.SoftLayer_User_Customer, error)
+	EditObject(userId int, template data_types.SoftLayer_User_Customer) (bool, error)
+	DeleteObject(userId int) (bool, error)
+
+	AddApiAuthenticationKey(userId int) error
+	GetApiAuthenticationKeys(userId int) ([]data_types.SoftLayer_User_Customer_ApiAuthentication, error)
+	RemoveApiAuthenticationKey(userId int, apiKeys []data_types.SoftLayer_User_Customer_ApiAuthentication) (bool, error)
+
+	AddBulkPortalPermission(userId int, permissions []data_types.SoftLayer_User_Customer_CustomerPermission_Permission) error
+	RemoveBulkPortalPermission(userId int, permissions []data_types.SoftLayer_User_Customer_CustomerPermission_Permission) error
+	GetPermissions(userId int) ([]data_types.SoftLayer_User_Customer_CustomerPermission_Permission, error)
+}

--- a/vendor/github.com/TheWeatherCompany/softlayer-go/softlayer/softlayer_virtual_disk_image_service.go
+++ b/vendor/github.com/TheWeatherCompany/softlayer-go/softlayer/softlayer_virtual_disk_image_service.go
@@ -1,0 +1,11 @@
+package softlayer
+
+import (
+	datatypes "github.com/TheWeatherCompany/softlayer-go/data_types"
+)
+
+type SoftLayer_Virtual_Disk_Image_Service interface {
+	Service
+
+	GetObject(id int) (datatypes.SoftLayer_Virtual_Disk_Image, error)
+}

--- a/vendor/github.com/TheWeatherCompany/softlayer-go/softlayer/softlayer_virtual_guest_block_device_template_group.go
+++ b/vendor/github.com/TheWeatherCompany/softlayer-go/softlayer/softlayer_virtual_guest_block_device_template_group.go
@@ -1,0 +1,38 @@
+package softlayer
+
+import (
+	datatypes "github.com/TheWeatherCompany/softlayer-go/data_types"
+)
+
+type SoftLayer_Virtual_Guest_Block_Device_Template_Group_Service interface {
+	Service
+
+	AddLocations(id int, locations []datatypes.SoftLayer_Location) (bool, error)
+
+	CreateFromExternalSource(configuration datatypes.SoftLayer_Container_Virtual_Guest_Block_Device_Template_Configuration) (datatypes.SoftLayer_Virtual_Guest_Block_Device_Template_Group, error)
+	CreatePublicArchiveTransaction(id int, groupName string, summary string, note string, locations []datatypes.SoftLayer_Location) (int, error)
+	CopyToExternalSource(configuration datatypes.SoftLayer_Container_Virtual_Guest_Block_Device_Template_Configuration) (bool, error)
+
+	DeleteObject(id int) (datatypes.SoftLayer_Provisioning_Version1_Transaction, error)
+	DenySharingAccess(id int, accountId int) (bool, error)
+
+	GetObject(id int) (datatypes.SoftLayer_Virtual_Guest_Block_Device_Template_Group, error)
+	GetDatacenters(id int) ([]datatypes.SoftLayer_Location, error)
+	GetSshKeys(id int) ([]datatypes.SoftLayer_Security_Ssh_Key, error)
+	GetStatus(id int) (datatypes.SoftLayer_Virtual_Guest_Block_Device_Template_Group_Status, error)
+
+	GetStorageLocations(id int) ([]datatypes.SoftLayer_Location, error)
+
+	GetImageType(id int) (datatypes.SoftLayer_Image_Type, error)
+	GetImageTypeKeyName(id int) (string, error)
+
+	GetTransaction(id int) (datatypes.SoftLayer_Provisioning_Version1_Transaction, error)
+
+	GetGlobalIdentifier(id int) (string, error)
+
+	PermitSharingAccess(id int, accountId int) (bool, error)
+
+	RemoveLocations(id int, locations []datatypes.SoftLayer_Location) (bool, error)
+
+	SetAvailableLocations(id int, locations []datatypes.SoftLayer_Location) (bool, error)
+}

--- a/vendor/github.com/TheWeatherCompany/softlayer-go/softlayer/softlayer_virtual_guest_service.go
+++ b/vendor/github.com/TheWeatherCompany/softlayer-go/softlayer/softlayer_virtual_guest_service.go
@@ -1,0 +1,67 @@
+package softlayer
+
+import (
+	datatypes "github.com/TheWeatherCompany/softlayer-go/data_types"
+)
+
+type UpgradeOptions struct {
+	Cpus       int
+	MemoryInGB int // Softlayer allows to upgrade Memory only in GB
+	NicSpeed   int
+}
+
+type SoftLayer_Virtual_Guest_Service interface {
+	Service
+
+	ActivatePrivatePort(instanceId int) (bool, error)
+	ActivatePublicPort(instanceId int) (bool, error)
+	AttachDiskImage(instanceId int, imageId int) (datatypes.SoftLayer_Provisioning_Version1_Transaction, error)
+	AttachEphemeralDisk(instanceId int, diskSize int) (datatypes.SoftLayer_Container_Product_Order_Receipt, error)
+
+	CaptureImage(instanceId int) (datatypes.SoftLayer_Container_Disk_Image_Capture_Template, error)
+	CheckHostDiskAvailability(instanceId int, diskCapacity int) (bool, error)
+	ConfigureMetadataDisk(instanceId int) (datatypes.SoftLayer_Provisioning_Version1_Transaction, error)
+	CreateArchiveTransaction(instanceId int, groupName string, blockDevices []datatypes.SoftLayer_Virtual_Guest_Block_Device, note string) (datatypes.SoftLayer_Provisioning_Version1_Transaction, error)
+	CreateObject(template datatypes.SoftLayer_Virtual_Guest_Template) (datatypes.SoftLayer_Virtual_Guest, error)
+
+	DeleteObject(instanceId int) (bool, error)
+	DetachDiskImage(instanceId int, imageId int) (datatypes.SoftLayer_Provisioning_Version1_Transaction, error)
+
+	EditObject(instanceId int, template datatypes.SoftLayer_Virtual_Guest) (bool, error)
+
+	IsPingable(instanceId int) (bool, error)
+	IsBackendPingable(instanceId int) (bool, error)
+
+	GetActiveTransaction(instanceId int) (datatypes.SoftLayer_Provisioning_Version1_Transaction, error)
+	GetLastTransaction(instanceId int) (datatypes.SoftLayer_Provisioning_Version1_Transaction, error)
+	GetActiveTransactions(instanceId int) ([]datatypes.SoftLayer_Provisioning_Version1_Transaction, error)
+	GetAllowedHost(instanceId int) (datatypes.SoftLayer_Network_Storage_Allowed_Host, error)
+	GetNetworkVlans(instanceId int) ([]datatypes.SoftLayer_Network_Vlan, error)
+	GetObject(instanceId int) (datatypes.SoftLayer_Virtual_Guest, error)
+	GetObjectByPrimaryIpAddress(ipAddress string) (datatypes.SoftLayer_Virtual_Guest, error)
+	GetObjectByPrimaryBackendIpAddress(ipAddress string) (datatypes.SoftLayer_Virtual_Guest, error)
+	GetPrimaryIpAddress(instanceId int) (string, error)
+	GetPowerState(instanceId int) (datatypes.SoftLayer_Virtual_Guest_Power_State, error)
+	GetSshKeys(instanceId int) ([]datatypes.SoftLayer_Security_Ssh_Key, error)
+	GetTagReferences(instanceId int) ([]datatypes.SoftLayer_Tag_Reference, error)
+	GetUpgradeItemPrices(instanceId int) ([]datatypes.SoftLayer_Product_Item_Price, error)
+	GetUserData(instanceId int) ([]datatypes.SoftLayer_Virtual_Guest_Attribute, error)
+	GetAvailableUpgradeItemPrices(upgradeOptions *UpgradeOptions) ([]datatypes.SoftLayer_Product_Item_Price, error)
+
+	PowerCycle(instanceId int) (bool, error)
+	PowerOff(instanceId int) (bool, error)
+	PowerOffSoft(instanceId int) (bool, error)
+	PowerOn(instanceId int) (bool, error)
+
+	RebootDefault(instanceId int) (bool, error)
+	RebootSoft(instanceId int) (bool, error)
+	RebootHard(instanceId int) (bool, error)
+
+	SetMetadata(instanceId int, metadata string) (bool, error)
+	SetTags(instanceId int, tags []string) (bool, error)
+	ShutdownPrivatePort(instanceId int) (bool, error)
+	ShutdownPublicPort(instanceId int) (bool, error)
+	ReloadOperatingSystem(instanceId int, template datatypes.Image_Template_Config) error
+
+	UpgradeObject(instanceId int, upgradeOptions *UpgradeOptions) (bool, error)
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -186,6 +186,36 @@
 			"revision": "0290933f5e8afd933f2823fce32bf2847e6ea603"
 		},
 		{
+			"checksumSHA1": "HsIGOQjx5ER7CqsHbLdk3f0HHEg=",
+			"path": "github.com/TheWeatherCompany/softlayer-go/client",
+			"revision": "36c2a33266d9a2dacb12c5772a500dc7fa3e3b6a",
+			"revisionTime": "2016-06-08T22:42:16Z"
+		},
+		{
+			"checksumSHA1": "YKbmwVbAebRVC0NGPAnb1q8Y0xs=",
+			"path": "github.com/TheWeatherCompany/softlayer-go/common",
+			"revision": "36c2a33266d9a2dacb12c5772a500dc7fa3e3b6a",
+			"revisionTime": "2016-06-08T22:42:16Z"
+		},
+		{
+			"checksumSHA1": "G6TmL65ynDX0RK76LmzgELGghlw=",
+			"path": "github.com/TheWeatherCompany/softlayer-go/data_types",
+			"revision": "36c2a33266d9a2dacb12c5772a500dc7fa3e3b6a",
+			"revisionTime": "2016-06-08T22:42:16Z"
+		},
+		{
+			"checksumSHA1": "XOsa+MRvn1jjhC+l/a3ok88mnj0=",
+			"path": "github.com/TheWeatherCompany/softlayer-go/services",
+			"revision": "36c2a33266d9a2dacb12c5772a500dc7fa3e3b6a",
+			"revisionTime": "2016-06-08T22:42:16Z"
+		},
+		{
+			"checksumSHA1": "RM4VSyk7+q65xFX9WFqk1nhoSMI=",
+			"path": "github.com/TheWeatherCompany/softlayer-go/softlayer",
+			"revision": "36c2a33266d9a2dacb12c5772a500dc7fa3e3b6a",
+			"revisionTime": "2016-06-08T22:42:16Z"
+		},
+		{
 			"path": "github.com/Unknwon/com",
 			"revision": "28b053d5a2923b87ce8c5a08f3af779894a72758"
 		},
@@ -997,31 +1027,6 @@
 		{
 			"path": "github.com/mattn/go-isatty",
 			"revision": "56b76bdf51f7708750eac80fa38b952bb9f32639"
-		},
-		{
-			"comment": "v0.6.0",
-			"path": "github.com/maximilien/softlayer-go/client",
-			"revision": "85659debe44fab5792fc92cf755c04b115b9dc19"
-		},
-		{
-			"comment": "v0.6.0",
-			"path": "github.com/maximilien/softlayer-go/common",
-			"revision": "85659debe44fab5792fc92cf755c04b115b9dc19"
-		},
-		{
-			"comment": "v0.6.0",
-			"path": "github.com/maximilien/softlayer-go/data_types",
-			"revision": "85659debe44fab5792fc92cf755c04b115b9dc19"
-		},
-		{
-			"comment": "v0.6.0",
-			"path": "github.com/maximilien/softlayer-go/services",
-			"revision": "85659debe44fab5792fc92cf755c04b115b9dc19"
-		},
-		{
-			"comment": "v0.6.0",
-			"path": "github.com/maximilien/softlayer-go/softlayer",
-			"revision": "85659debe44fab5792fc92cf755c04b115b9dc19"
 		},
 		{
 			"path": "github.com/mitchellh/cli",

--- a/website/source/docs/providers/softlayer/r/user_customer.html.markdown
+++ b/website/source/docs/providers/softlayer/r/user_customer.html.markdown
@@ -1,0 +1,142 @@
+---
+layout: "softlayer"
+page_title: "SoftLayer: user_customer"
+sidebar_current: "docs-softlayer-resource-softlayer-user-customer"
+description: |-
+  Manages SoftLayer Users.
+---
+
+# softlayer\user
+
+Represents the SoftLayer's user login resource. You can get, create,
+update and delete this resource. For additional details please refer to
+[SoftLayer API documentation](http://sldn.softlayer.com/reference/datatypes/SoftLayer_User_Customer).
+
+Also see additional notes below.
+
+## Example Usage
+
+```
+resource "softlayer_user" "joe" {
+	address1     = "12345 Any Street"
+	address2     = "Suite #99"
+	city         = "Atlanta"
+	company_name = "Comp Inc"
+	country      = "US"
+	email        = "joe@doe.com"
+	first_name   = "Joe"
+	has_api_key  = false
+	last_name    = "Doe"
+	password     = "Change3Me!"
+	permissions  = [
+		"ACCESS_ALL_GUEST",
+		"ACCESS_ALL_HARDWARE",
+		"SERVER_ADD",
+		"SERVER_CANCEL",
+		"RESET_PORTAL_PASSWORD"
+	]
+	state        = "GA"
+	timezone     = 114
+	user_status  = 1001
+	username     = "joedoe"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `address1` | *string*
+    * User's street address first line.
+    * **Required**
+* `address2` | *string*
+    * User's street address second line.
+    * *Default*: ""
+    * *Optional*
+* `city` | *string*
+    * User's street address city.
+    * **Required**
+* `company_name` | *string*
+    * User's company name.
+    * **Required**
+* `country` | *string*
+    * User's street address country.
+    * **Required**
+* `email` | *string*
+    * User's email address associated with this login userid.
+    * **Required**
+* `first_name` | *string*
+    * User's first name.
+    * **Required**
+* `has_api_key` | *boolean*
+    * This flag when true specifies that a new SoftLayer API key
+      be created for this user. They key is returned back in the
+      `api_key` computed attribute.
+    * *Default*: False
+    * *Optional* - When false, it will delete any api key that was 
+      previously created.
+    * **Required**
+* `last_name` | *string*
+    * User's last name.
+    * **Required**
+* `password` | *string*
+    * Initial password for this new user login. This string value must
+      conform to SoftLayer's portal password to avoid failures. You can
+      find the password policies in your SoftLayer portal profile page.
+      At the time of this writing, valid passwords must be 8 to 20 characters
+      in length with a combination of UPPER and lower case characters, at
+      least one number, and at least one of the following special
+      characters: `_-|@.,?/!~#$%^&*(){}[]=`. The password specified here
+      is 'hashed' and 'encoded' before it is stored in the Terraform
+      state file.
+    * **Required**
+* `permissions` | *array of strings*
+    * Permissions assigned to this user. This is a set of zero or more
+      string values. See [SoftLayer_User_Customer_CustomerPermission_Permission](http://sldn.softlayer.com/reference/datatypes/SoftLayer_User_Customer_CustomerPermission_Permission).
+    * *Default*: []
+    * *Optional*
+* `state` | *string*
+    * User's street address state.
+    * **Required**
+* `timezone` | *int*
+    * User's timezone id (no validation checks with the street address).
+      Value is one of [SoftLayer_Locale_Timezone](http://sldn.softlayer.com/reference/datatypes/SoftLayer_Locale_Timezone).
+    * **Required**
+* `user_status` | *int*
+    * Status id of user's login status. Value is one of
+      [SoftLayer_User_Customer_Status](http://sldn.softlayer.com/reference/datatypes/SoftLayer_User_Customer_Status).
+    * *Optional*
+	* *Default*: 1001 // means 'active'
+* `username` | *string*
+    * A name that uniquely identifies a user globally across all SoftLayer
+      logins. It is also the login userid. Once a user login is created,
+      it cannot be changed.
+    * **Required**
+
+All fields except `username` are editable.
+
+## Attributes Reference
+
+The following computed attributes are returned:
+
+* `api_key` | *string*
+    * SoftLayer API key that was created for this new user.
+    * *Computed*
+* `id` | *string*
+    * Unique SoftLayer id for this new user.
+    * *Computed*
+
+
+## Additional notes
+
+In SoftLayer, when user logins are deleted, there is a delay when that
+login actually gets deleted in the SoftLayer backend systems. SoftLayer
+successfully acknowledges the delete request and immediately updates the
+user status to CANCEL_PENDING. Actual deletion of happens at some
+unspecified amount of time in the future. This delay may be significant
+especially during your projects testing phase. If you create a new user
+login, and then delete it, and then create it again, you may receive an
+error, as SoftLayer backend has not completely processed the previous delete
+operation. If you do want to run through this create-delete-create-again
+cycle again, you will have to specify a new globally unique username value
+in your subsequent requests.

--- a/website/source/layouts/softlayer.erb
+++ b/website/source/layouts/softlayer.erb
@@ -13,14 +13,18 @@
 				<li<%= sidebar_current(/^docs-softlayer-resource/) %>>
 					<a href="#">Resources</a>
 					<ul class="nav nav-visible">
-						<li<%= sidebar_current("docs-softlayer-resource-virtual-guest") %>>
-							<a href="/docs/providers/softlayer/r/virtual_guest.html">virtual_guest</a>
+						<li<%= sidebar_current("docs-softlayer-resource-softlayer-user-customer") %>>
+							<a href="/docs/providers/softlayer/r/user_customer.html">softlayer_user</a>
 						</li>
 						<li<%= sidebar_current("docs-softlayer-resource-ssh-key") %>>
 							<a href="/docs/providers/softlayer/r/ssh_key.html">ssh_key</a>
 						</li>
+						<li<%= sidebar_current("docs-softlayer-resource-virtual-guest") %>>
+							<a href="/docs/providers/softlayer/r/virtual_guest.html">virtual_guest</a>
+						</li>
 					</ul>
 				</li>
+
 			</ul>
 		</div>
 	<% end %>


### PR DESCRIPTION
- Implemented a softlayer_user resource, supporting the following:
  - Set/change common user fields (username, password, first/last name, address, etc.).
  - Ability to generate (and revoke) an API key by specifying `has_api_key = true` (or `false`) in a terraform config file
  - Ability to set/modify user permissions, by providing a list of permission "key" (string) values
- References to github.com/maximilien/softlayer-go changed to github.com/TheWeatherCompany/softlayer-go
- Created acceptance tests for creating and updating softlayer_user resources.
- Added documentation for softlayer_users
