### PR TITLE
Add Check Destroy function in acceptance test  for resource CF service and serviceKey 

### DIFF
--- a/builtin/providers/ibmcloud/resource_ibmcloud_cf_service_instance.go
+++ b/builtin/providers/ibmcloud/resource_ibmcloud_cf_service_instance.go
@@ -135,9 +135,8 @@ func resourceIBMCloudCfServiceInstanceUpdate(d *schema.ResourceData, meta interf
 	var name, planguid string
 	var parameters map[string]interface{}
 	var tags []string
-	if d.HasChange("name") {
-		name = d.Get("name").(string)
-	}
+
+	name = d.Get("name").(string)
 
 	if d.HasChange("plan") {
 		plan := d.Get("plan").(string)


### PR DESCRIPTION
Check Destroy function checks whether the resource has been destroyed or not.It throws an error if the resource doesn't get destroyed.